### PR TITLE
KOV 349 : jwt 토큰 DB 조회 / 유효성 검증 / 재발급

### DIFF
--- a/user-service/src/main/java/com/newcord/userservice/auth/api/KakaoController.java
+++ b/user-service/src/main/java/com/newcord/userservice/auth/api/KakaoController.java
@@ -1,16 +1,13 @@
 package com.newcord.userservice.auth.api;
 
-
 import com.newcord.userservice.auth.jwt.JwtTokenProvider;
 import com.newcord.userservice.auth.response.ApiResponse;
-import com.newcord.userservice.auth.response.ResponseCode;
 import com.newcord.userservice.auth.service.KakaoAuthService;
 import com.newcord.userservice.auth.utils.KakaoTokenJsonData;
 import com.newcord.userservice.auth.utils.dto.KakaoTokenResponse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Description;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -24,12 +21,14 @@ import java.util.HashMap;
 public class KakaoController {
     private final KakaoTokenJsonData kakaoTokenJsonData;
     private final KakaoAuthService kakaoAuthService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @GetMapping("/")
     public String index() {
         return "index";
     }
 
+    // 카카오 로그인 + 토큰 발급
     @GetMapping("/login")
     @ResponseBody
     public ApiResponse<HashMap<String, String>> kakaoOauth(@RequestParam("code") String code) {
@@ -37,11 +36,56 @@ public class KakaoController {
         KakaoTokenResponse kakaoTokenResponse = kakaoTokenJsonData.getToken(code);
         log.info("토큰에 대한 정보입니다.{}",kakaoTokenResponse);
 
+        // 카카오 토큰을 사용하여 회원가입 여부를 확인하고 Jwt 토큰을 발급
         ApiResponse<HashMap<String, String>> response = kakaoAuthService.authCheck(kakaoTokenResponse.getAccess_token());
-        log.info("jwt 토큰 생성 완료: {}", response.getResult().get("token"));
-        log.info("jwt refresh 토큰 생성 완료: {}", response.getResult().get("refreshToken"));
 
         return response;
+    }
+
+    // jwt 엑세스 토큰을 받으면 토큰을 해독하여 유저 아이디를 조회하고 반환
+    @GetMapping("/decode")
+    @ResponseBody
+    public ApiResponse<Long> decodeToken(@RequestHeader("X-AUTH-TOKEN") String jwtToken) {
+        String userIdString = jwtTokenProvider.getUserPk(jwtToken);
+        log.info("해독된 유저 아이디: {}", userIdString);
+
+        // 유저 아이디를 Long 타입으로 변환
+        Long userId = null;
+        userId = Long.parseLong(userIdString);
+
+        // 유저 아이디를 가지고 디비에 있는지 확인
+        boolean userExists = kakaoAuthService.isUserExists(userId);
+        if (!userExists) {
+            log.error("User not found in database with ID: {}", userId);
+            return ApiResponse.error("User not found in database");
+        }
+        return ApiResponse.success(userId, "User ID retrieved successfully.");
+    }
+
+    // jwt 엑세스 토큰 유효성을 검증
+    @GetMapping("/validate")
+    @ResponseBody
+    public ApiResponse<Boolean> validateToken(@RequestHeader("X-AUTH-TOKEN") String jwtToken) {
+        boolean isValid = jwtTokenProvider.validateToken(jwtToken);
+        log.info("JWT 토큰 유효성 검증 결과: {}", isValid);
+        return ApiResponse.success(isValid, "Token validation successful.");
+    }
+
+    // jwt 리프레시 토큰 유효할 때 jwt 엑세스 토큰 재발급
+    @GetMapping("/issueToken")
+    @ResponseBody
+    public ApiResponse<HashMap<String, String>> issueToken(@RequestHeader("X-REFRESH-TOKEN") String refreshToken) {
+        boolean isRefreshTokenValid = jwtTokenProvider.validateRefreshToken(refreshToken);
+        if (isRefreshTokenValid) {
+            String accessToken = jwtTokenProvider.refreshAccessToken(refreshToken);
+            HashMap<String, String> map = new HashMap<>();
+            map.put("accessToken", accessToken);
+            log.info("발급된 액세스 토큰: {}", accessToken);
+            return ApiResponse.success(map, "Access token issued successfully.");
+        } else {
+            log.error("JWT 리프레시 토큰이 유효하지 않습니다.");
+            return ApiResponse.error("Refresh token validation failed.");
+        }
     }
 
 }

--- a/user-service/src/main/java/com/newcord/userservice/auth/jwt/JwtTokenProvider.java
+++ b/user-service/src/main/java/com/newcord/userservice/auth/jwt/JwtTokenProvider.java
@@ -13,7 +13,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 
 import java.util.Base64;

--- a/user-service/src/main/java/com/newcord/userservice/auth/response/ApiResponse.java
+++ b/user-service/src/main/java/com/newcord/userservice/auth/response/ApiResponse.java
@@ -22,6 +22,10 @@ public class ApiResponse<T> {
         return new ApiResponse<>(true, message, result);
     }
 
+    public static <T> ApiResponse<T> error(String message) {
+        return new ApiResponse<>(false, message, null);
+    }
+
     public static <T> ApiResponse<T> failure(String message) {
         return new ApiResponse<>(false, message, null);
     }

--- a/user-service/src/main/java/com/newcord/userservice/auth/service/KakaoAuthService.java
+++ b/user-service/src/main/java/com/newcord/userservice/auth/service/KakaoAuthService.java
@@ -26,31 +26,40 @@ public class KakaoAuthService {
     private final UsersRepository usersRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
+
+    // 카카오에서 엑세스 토큰 받아와서 회원정보 가져오고 검증함
     @Transactional
     public Long isSignedUp(String token) {
         KakaoUserInfoResponse userInfo = kakaoUserInfo.getUserInfo(token);
         log.info("회원 정보 입니다.{}", userInfo);
 
         Long userId = userInfo.getId();
-        Users user = usersRepository.findById(userId).orElse(null);
-        if (user == null) {
-            // 사용자가 존재하지 않는 경우에만 createUser 호출
-            return createUser(userId, userInfo.getProperties().getNickname(), userInfo.getProperties().getProfile_image());
-        }
         return userId;
     }
 
     @Transactional
-    public Long createUser(Long id, String nickName, String profileImg) {
+    public boolean isUserExists(Long userId) {
+        Users user = usersRepository.findById(userId).orElse(null);
+        return user != null;
+    }
+
+
+    // 유저 정보 추가
+    @Transactional
+    public Long createUser(String token) {
+        KakaoUserInfoResponse userInfo = kakaoUserInfo.getUserInfo(token);
+        log.info("회원 정보 입니다.{}", userInfo);
+
+        Long userId = userInfo.getId();
         Users user = Users.builder()
-                .id(id)
-                .nickName(nickName)
-                .profileImg(profileImg)
+                .id(userId)
+                .nickName(userInfo.getProperties().getNickname())
+                .profileImg(userInfo.getProperties().getProfile_image())
                 .build();
 
         usersRepository.save(user);
         log.info("새로운 회원 저장 완료");
-        return user.getId();
+        return userId;
     }
 
     // refresh token db 저장
@@ -66,12 +75,21 @@ public class KakaoAuthService {
     @Transactional
     public ApiResponse<HashMap<String, String>> authCheck(@RequestHeader String accessToken) {
         Long userId = isSignedUp(accessToken); // 유저 고유번호 추출
-        String refreshToken = jwtTokenProvider.createRefreshToken(userId.toString());
+        String refreshToken;
+
+        boolean userExists = isUserExists(userId);
+        if (!userExists) {
+            // 사용자가 존재하지 않으면 회원 가입
+            createUser(accessToken);
+        }
+
+        refreshToken = jwtTokenProvider.createRefreshToken(userId.toString());
+
         saveRefreshToken(userId, refreshToken); // 리프레시 토큰 db 저장
 
         HashMap<String, String> map = new HashMap<>();
         map.put("userId", userId.toString());
-        map.put("token", jwtTokenProvider.createToken(userId.toString()));
+        map.put("token", jwtTokenProvider.createToken(userId.toString())); // 유저 아이디로 jwt 토큰 발급
         map.put("refreshToken", refreshToken);
         return ApiResponse.success(map, ResponseCode.USER_LOGIN_SUCCESS.getMessage());
     }

--- a/user-service/src/main/resources/static/index.html
+++ b/user-service/src/main/resources/static/index.html
@@ -4,7 +4,7 @@
     <title>Kakao Login</title>
 </head>
 <body>
-<a href="https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=a61af306bdb89fc8bbbaced44fb4fef0&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fapi%2Fauth%2Flogin">
+<a href="https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=a61af306bdb89fc8bbbaced44fb4fef0&redirect_uri=http%3A%2F%2Flocalhost%3A8081%2Fapi%2Fauth%2Flogin">
     Kakao 로그인
 </a>
 </body>


### PR DESCRIPTION
# 요약
- 엑세스 토큰 해독하여 DB 조회
- 엑세스 토큰 유효성 검증
- 리프레시 토큰 유효성 검증 후 엑세스 토큰 재발급


# 변경사항
- 엑세스 토큰 해독 -> user id -> DB 조회하여 user id 존재하는지 검증 -> 존재하는 경우 user id 반환
- 엑세스 토큰 유효한지 검증
- 리프레시 토큰 유효한 경우 -> 엑세스 토큰 재발급 

따라서 사용자는 엑세스 토큰이 만료된 경우 리프레시 토큰으로 재시도, 
리프레시 토큰이 유효한 경우 엑세스 토큰 재발급, 리프레시 토큰도 유효하지 않은 경우 재로그인 필요

# 결과
<img width="594" alt="스크린샷 2024-05-08 오전 3 14 51" src="https://github.com/KEA-Kovengers/Backend/assets/125250173/5a9f46ea-68e0-42e0-aac0-e695e38c84ef">

<img width="654" alt="스크린샷 2024-05-08 오전 3 15 13" src="https://github.com/KEA-Kovengers/Backend/assets/125250173/c873a79a-5398-459a-8bed-eded629bcc96">

<img width="690" alt="스크린샷 2024-05-08 오전 3 15 50" src="https://github.com/KEA-Kovengers/Backend/assets/125250173/1ddd04ac-12c4-4f76-a4db-f9fc17047456">

# 이슈넘버
- KOV 349
