### PR TITLE
Kov 371 [Refactor] 게시글 서비스 순환참조 해결

### DIFF
--- a/article-service/src/main/java/com/newcord/articleservice/config/WebSocketConfig.java
+++ b/article-service/src/main/java/com/newcord/articleservice/config/WebSocketConfig.java
@@ -27,7 +27,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws/test").setAllowedOrigins("*");
+        registry.addEndpoint("/ws").setAllowedOrigins("*");
     }
 
     @Override

--- a/article-service/src/main/java/com/newcord/articleservice/domain/articles/controller/ArticleController.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/articles/controller/ArticleController.java
@@ -2,6 +2,7 @@ package com.newcord.articleservice.domain.articles.controller;
 
 import com.newcord.articleservice.domain.articles.dto.ArticleRequest.BlockSequenceUpdateRequestDTO;
 import com.newcord.articleservice.domain.articles.dto.ArticleResponse.BlockSequenceUpdateResponseDTO;
+import com.newcord.articleservice.domain.articles.service.ArticleComposeService;
 import com.newcord.articleservice.domain.articles.service.ArticlesCommandService;
 import com.newcord.articleservice.domain.block.dto.BlockRequest.BlockContentUpdateRequestDTO;
 import com.newcord.articleservice.global.common.WSRequest;
@@ -20,12 +21,12 @@ import org.springframework.web.bind.annotation.PostMapping;
 @RequiredArgsConstructor
 @Slf4j
 public class ArticleController {
-    private final ArticlesCommandService articlesCommandService;
+    private final ArticleComposeService articleComposeService;
     private final RabbitMQService rabbitMQService;
 
     @MessageMapping("/updateBlockSequence/{postID}")
     public WSResponse<BlockSequenceUpdateResponseDTO> updateBlockSequence(WSRequest<BlockSequenceUpdateRequestDTO> requestDTO, @DestinationVariable Long postID) {
-        BlockSequenceUpdateResponseDTO responseDTO = articlesCommandService.updateBlockSequence(postID,requestDTO.getDto());
+        BlockSequenceUpdateResponseDTO responseDTO = articleComposeService.updateBlockSequence("testID", postID, requestDTO.getDto());
         WSResponse<BlockSequenceUpdateResponseDTO> response = WSResponse.onSuccess("/updateBlockSequence/"+postID, requestDTO.getUuid(), responseDTO);
         rabbitMQService.sendMessage(postID.toString(), "", response);
 

--- a/article-service/src/main/java/com/newcord/articleservice/domain/articles/service/ArticleComposeService.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/articles/service/ArticleComposeService.java
@@ -8,11 +8,7 @@ import com.newcord.articleservice.domain.block.entity.Block;
 import java.util.List;
 
 public interface ArticleComposeService {
-    ArticleCreateResponseDTO createArticle(Long articleID);            // 게시글 생성(MongoDB용)
-    BlockSequenceUpdateResponseDTO insertBlock(Long articleID, InsertBlockRequestDTO insertBlockRequestDTO);            // 새로운 블럭을 게시글에 추가할때 사용
-    BlockSequenceUpdateResponseDTO updateBlockSequence(Long articleID,
+    BlockSequenceUpdateResponseDTO updateBlockSequence(String userID, Long articleID,
         BlockSequenceUpdateRequestDTO blockSequenceUpdateRequestDTO);        // 게시글 내 블럭 순서 변경
-    List<String> deleteBlockFromBlockList(Long articleID, Block block);            // 게시글 내 블럭 삭제
-    void deleteArticle(Long articleID);            // 게시글 삭제
 
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/articles/service/ArticleComposeService.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/articles/service/ArticleComposeService.java
@@ -4,18 +4,15 @@ import com.newcord.articleservice.domain.articles.dto.ArticleRequest.BlockSequen
 import com.newcord.articleservice.domain.articles.dto.ArticleRequest.InsertBlockRequestDTO;
 import com.newcord.articleservice.domain.articles.dto.ArticleResponse.ArticleCreateResponseDTO;
 import com.newcord.articleservice.domain.articles.dto.ArticleResponse.BlockSequenceUpdateResponseDTO;
-import com.newcord.articleservice.domain.articles.entity.Article;
 import com.newcord.articleservice.domain.block.entity.Block;
 import java.util.List;
 
-public interface ArticlesCommandService {
-    Article createArticle(Long articleID);            // 게시글 생성(MongoDB용)
-    Article insertBlock(Long articleID, InsertBlockRequestDTO insertBlockRequestDTO);            // 새로운 블럭을 게시글에 추가할때 사용
-    Article updateBlockSequence(Long articleID,
+public interface ArticleComposeService {
+    ArticleCreateResponseDTO createArticle(Long articleID);            // 게시글 생성(MongoDB용)
+    BlockSequenceUpdateResponseDTO insertBlock(Long articleID, InsertBlockRequestDTO insertBlockRequestDTO);            // 새로운 블럭을 게시글에 추가할때 사용
+    BlockSequenceUpdateResponseDTO updateBlockSequence(Long articleID,
         BlockSequenceUpdateRequestDTO blockSequenceUpdateRequestDTO);        // 게시글 내 블럭 순서 변경
-    Article deleteBlockFromBlockList(Long articleID, Block block);            // 게시글 내 블럭 삭제
-    Article deleteArticle(Long articleID);            // 게시글 삭제
-
-
+    List<String> deleteBlockFromBlockList(Long articleID, Block block);            // 게시글 내 블럭 삭제
+    void deleteArticle(Long articleID);            // 게시글 삭제
 
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/articles/service/ArticleComposeServiceImpl.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/articles/service/ArticleComposeServiceImpl.java
@@ -1,0 +1,5 @@
+package com.newcord.articleservice.domain.articles.service;
+
+public class ArticleComposeServiceImpl implements ArticleComposeService{
+
+}

--- a/article-service/src/main/java/com/newcord/articleservice/domain/articles/service/ArticleComposeServiceImpl.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/articles/service/ArticleComposeServiceImpl.java
@@ -1,5 +1,36 @@
 package com.newcord.articleservice.domain.articles.service;
 
+import com.newcord.articleservice.domain.articles.dto.ArticleRequest.BlockSequenceUpdateRequestDTO;
+import com.newcord.articleservice.domain.articles.dto.ArticleRequest.InsertBlockRequestDTO;
+import com.newcord.articleservice.domain.articles.dto.ArticleResponse.ArticleCreateResponseDTO;
+import com.newcord.articleservice.domain.articles.dto.ArticleResponse.BlockSequenceUpdateResponseDTO;
+import com.newcord.articleservice.domain.articles.entity.Article;
+import com.newcord.articleservice.domain.block.entity.Block;
+import com.newcord.articleservice.domain.block.service.BlockCommandService;
+import com.newcord.articleservice.domain.editor.service.EditorCommandService;
+import com.newcord.articleservice.domain.editor.service.EditorQueryService;
+import com.newcord.articleservice.rabbitMQ.Service.RabbitMQService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class ArticleComposeServiceImpl implements ArticleComposeService{
+    private final ArticlesCommandService articlesCommandService;
+    private final EditorQueryService editorQueryService;
+
+    @Override
+    public BlockSequenceUpdateResponseDTO updateBlockSequence(String userID, Long articleID,
+        BlockSequenceUpdateRequestDTO blockSequenceUpdateRequestDTO) {
+        // 권한 확인
+        editorQueryService.getEditorByPostIdAndUserID(articleID, userID);
+
+        Article article = articlesCommandService.updateBlockSequence(articleID, blockSequenceUpdateRequestDTO);
+        return BlockSequenceUpdateResponseDTO.builder()
+            .articleId(article.getId())
+            .blockList(article.getBlock_list())
+            .build();
+    }
 
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/articles/service/ArticlesCommandServiceImpl.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/articles/service/ArticlesCommandServiceImpl.java
@@ -87,6 +87,11 @@ public class ArticlesCommandServiceImpl implements ArticlesCommandService{
 
     @Override
     public Article deleteArticle(Long articleID) {
-        return null;
+        Article article = articlesRepository.findById(articleID)
+            .orElseThrow(() -> new ApiException(ErrorStatus._ARTICLE_NOT_FOUND));
+
+        articlesRepository.delete(article);
+
+        return article;
     }
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/articles/service/ArticlesCommandServiceImpl.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/articles/service/ArticlesCommandServiceImpl.java
@@ -18,10 +18,9 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ArticlesCommandServiceImpl implements ArticlesCommandService{
     private final ArticlesRepository articlesRepository;
-    private final ArticlesQueryService articlesQueryService;
 
     @Override
-    public ArticleCreateResponseDTO createArticle(Long articleID) {
+    public Article createArticle(Long articleID) {
         articlesRepository.findById(articleID)
             .ifPresent(a -> {
                 throw new ApiException(ErrorStatus._ARTICLE_ALREADY_EXISTS);
@@ -34,14 +33,13 @@ public class ArticlesCommandServiceImpl implements ArticlesCommandService{
 
         articlesRepository.save(article);
 
-        return ArticleCreateResponseDTO.builder()
-            .articleId(article.getId())
-            .build();
+        return article;
     }
 
     @Override
-    public BlockSequenceUpdateResponseDTO insertBlock(Long articleID, InsertBlockRequestDTO insertBlockRequestDTO) {
-        Article article = articlesQueryService.findArticleById(articleID);
+    public Article insertBlock(Long articleID, InsertBlockRequestDTO insertBlockRequestDTO) {
+        Article article = articlesRepository.findById(articleID)
+            .orElseThrow(() -> new ApiException(ErrorStatus._ARTICLE_NOT_FOUND));
 
         if(article.getBlock_list().contains(insertBlockRequestDTO.getBlock().getId().toString()))
             throw new ApiException(ErrorStatus._BLOCK_ALREADY_EXISTS);
@@ -50,17 +48,15 @@ public class ArticlesCommandServiceImpl implements ArticlesCommandService{
 
         articlesRepository.save(article);
 
-        return BlockSequenceUpdateResponseDTO.builder()
-            .articleId(article.getId())
-            .blockList(article.getBlock_list())
-            .build();
+        return article;
     }
 
     @Override
-    public BlockSequenceUpdateResponseDTO updateBlockSequence(
+    public Article updateBlockSequence(
         Long articleID,
         BlockSequenceUpdateRequestDTO blockSequenceUpdateRequestDTO) {
-        Article article = articlesQueryService.findArticleById(articleID);
+        Article article = articlesRepository.findById(articleID)
+            .orElseThrow(() -> new ApiException(ErrorStatus._ARTICLE_NOT_FOUND));
 
         for (int i = 0; i < blockSequenceUpdateRequestDTO.getBlockList().size(); i++) {
             int idx = article.getBlock_list().indexOf(blockSequenceUpdateRequestDTO.getBlockList().get(i));
@@ -75,24 +71,22 @@ public class ArticlesCommandServiceImpl implements ArticlesCommandService{
 
         articlesRepository.save(article);
 
-        return BlockSequenceUpdateResponseDTO.builder()
-            .articleId(article.getId())
-            .blockList(article.getBlock_list())
-            .build();
+        return article;
     }
 
     @Override
-    public List<String> deleteBlockFromBlockList(Long articleID, Block block) {
-        Article article = articlesQueryService.findArticleById(articleID);
+    public Article deleteBlockFromBlockList(Long articleID, Block block) {
+        Article article = articlesRepository.findById(articleID)
+            .orElseThrow(() -> new ApiException(ErrorStatus._ARTICLE_NOT_FOUND));
 
         article.getBlock_list().remove(block.getId().toString());
         articlesRepository.save(article);
 
-        return article.getBlock_list();
+        return article;
     }
 
     @Override
-    public void deleteArticle(Long articleID) {
-
+    public Article deleteArticle(Long articleID) {
+        return null;
     }
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/block/controller/BlockController.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/block/controller/BlockController.java
@@ -7,6 +7,7 @@ import com.newcord.articleservice.domain.block.dto.BlockResponse.BlockContentUpd
 import com.newcord.articleservice.domain.block.dto.BlockResponse.BlockCreateResponseDTO;
 import com.newcord.articleservice.domain.block.dto.BlockResponse.BlockDeleteResponseDTO;
 import com.newcord.articleservice.domain.block.service.BlockCommandService;
+import com.newcord.articleservice.domain.block.service.BlockComposeServiceImpl;
 import com.newcord.articleservice.global.common.WSRequest;
 import com.newcord.articleservice.global.common.response.ApiResponse;
 import com.newcord.articleservice.global.common.response.WSResponse;
@@ -22,11 +23,11 @@ import org.springframework.stereotype.Controller;
 @Slf4j
 public class BlockController {
     private final RabbitMQService rabbitMQService;
-    private final BlockCommandService blockCommandService;
+    private final BlockComposeServiceImpl blockComposeServiceImpl;
 
     @MessageMapping("/updateBlock/{postID}")
     public WSResponse<BlockContentUpdateResponseDTO> updateBlock(WSRequest<BlockContentUpdateRequestDTO> requestDTO, @DestinationVariable Long postID) {
-        BlockContentUpdateResponseDTO responseDTO = blockCommandService.updateBlock(requestDTO.getDto(), postID);
+        BlockContentUpdateResponseDTO responseDTO = blockComposeServiceImpl.updateBlock("testID", requestDTO.getDto(), postID);
         WSResponse<BlockContentUpdateResponseDTO> response = WSResponse.onSuccess("/updateBlock/"+postID, requestDTO.getUuid(), responseDTO);
 
         rabbitMQService.sendMessage(postID.toString(), "", response);
@@ -36,7 +37,7 @@ public class BlockController {
 
     @MessageMapping("/createBlock/{postID}")
     public WSResponse<BlockCreateResponseDTO> createBlock(WSRequest<BlockCreateRequestDTO> blockCreateRequestDTO, @DestinationVariable Long postID) {
-        BlockCreateResponseDTO responseDTO = blockCommandService.createBlock(blockCreateRequestDTO.getDto(), postID);
+        BlockCreateResponseDTO responseDTO = blockComposeServiceImpl.createBlock("testID", blockCreateRequestDTO.getDto(), postID);
         WSResponse<BlockCreateResponseDTO> response = WSResponse.onSuccess("/createBlock/"+postID, blockCreateRequestDTO.getUuid(), responseDTO);
         rabbitMQService.sendMessage(postID.toString(), "", response);
 
@@ -47,7 +48,7 @@ public class BlockController {
     // 요청시에 dto : {'blockId' : '~~`'} 가 아닌, dto : '~~' 로 보내야함
     @MessageMapping("/deleteBlock/{postID}")
     public WSResponse<BlockDeleteResponseDTO> deleteBlock(WSRequest<BlockDeleteRequestDTO> requestDTO, @DestinationVariable Long postID) {
-        BlockDeleteResponseDTO responseDTO = blockCommandService.deleteBlock(requestDTO.getDto(), postID);
+        BlockDeleteResponseDTO responseDTO = blockComposeServiceImpl.deleteBlock("testID", requestDTO.getDto(), postID);
         WSResponse<BlockDeleteResponseDTO> response = WSResponse.onSuccess("/deleteBlock/"+postID, requestDTO.getUuid(), responseDTO);
         rabbitMQService.sendMessage(postID.toString(), "", response);
 

--- a/article-service/src/main/java/com/newcord/articleservice/domain/block/dto/BlockRequest.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/block/dto/BlockRequest.java
@@ -35,7 +35,6 @@ public class BlockRequest {
     public static class BlockContentUpdateRequestDTO {
         private String blockId;               // 수정할 block ID
         private String blockType;           // block 타입
-        private Long position;              // block의 위치 (변경되지 않는다면 원래 값 그대로)
         private String content;             // 내용
         private BlockUpdatedBy updated_by;  // 수정자
     }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/block/dto/BlockResponse.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/block/dto/BlockResponse.java
@@ -53,7 +53,6 @@ public class BlockResponse {
     @Getter
     public static class BlockContentUpdateResponseDTO {
         private BlockDTO blockDTO;
-        private Long position;              // block의 위치 (변경되지 않는다면 원래 값 그대로)
         private BlockUpdatedBy updated_by;  // 수정자
     }
 

--- a/article-service/src/main/java/com/newcord/articleservice/domain/block/service/BlockCommandService.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/block/service/BlockCommandService.java
@@ -13,6 +13,6 @@ import com.newcord.articleservice.domain.block.entity.Block;
 // Block도메인에 대한 command 모듈 서비스이다. 저수준의 인터페이스 계층을 구현한다.
 public interface BlockCommandService {
     Block createBlock(BlockCreateRequestDTO blockCreateDTO, Long postId);        // 블럭 생성
-    Block updateBlock(BlockContentUpdateRequestDTO blockContentUpdateDTO, Long postId);        // 블럭 내용 수정
-    Block deleteBlock(BlockDeleteRequestDTO blockDeleteDTO, Long postId);        // 블럭 삭제
+    Block updateBlock(BlockContentUpdateRequestDTO blockContentUpdateDTO);        // 블럭 내용 수정
+    Block deleteBlock(String blockID);        // 블럭 삭제
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/block/service/BlockCommandServiceImpl.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/block/service/BlockCommandServiceImpl.java
@@ -26,11 +26,9 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class BlockCommandServiceImpl implements BlockCommandService{
     private final BlockRepository blockRepository;
-    private final ArticlesCommandService articlesCommandService;
-    private final ArticlesQueryService articlesQueryService;
 
     @Override
-    public BlockCreateResponseDTO createBlock(BlockCreateRequestDTO blockCreateDTO, Long postId) {
+    public Block createBlock(BlockCreateRequestDTO blockCreateDTO, Long postId) {
         blockCreateDTO.setArticleID(postId);
         // Block 생성
         BlockUpdatedBy blockUpdatedBy = BlockUpdatedBy.builder()
@@ -51,22 +49,11 @@ public class BlockCommandServiceImpl implements BlockCommandService{
         // Block 저장
         blockRepository.save(block);
 
-        // Article에 순서에 맞게 Insert
-        BlockSequenceUpdateResponseDTO responseDTO = articlesCommandService.insertBlock(postId, InsertBlockRequestDTO.builder()
-            .block(block)
-            .position(blockCreateDTO.getPosition())
-            .build());
-
-        return BlockCreateResponseDTO.builder()
-            .blockDTO(BlockDTO.toDTO(block))
-            .articleId(blockCreateDTO.getArticleID())
-            .position(blockCreateDTO.getPosition())
-            .blockList(responseDTO.getBlockList())
-            .build();
+        return block;
     }
 
     @Override
-    public BlockContentUpdateResponseDTO updateBlock(BlockContentUpdateRequestDTO blockContentUpdateDTO, Long postId) {
+    public Block updateBlock(BlockContentUpdateRequestDTO blockContentUpdateDTO, Long postId) {
         // 블록 업데이트 로직 후 ResponseDTO로 전송
         Block block = blockRepository.findById(new ObjectId(blockContentUpdateDTO.getBlockId())).orElseThrow(
                 () -> new ApiException(ErrorStatus._BLOCK_NOT_FOUND)
@@ -82,25 +69,18 @@ public class BlockCommandServiceImpl implements BlockCommandService{
         // 블록 업데이트 후 저장
         blockRepository.save(block);
 
-        return BlockContentUpdateResponseDTO.builder()
-            .blockDTO(BlockDTO.toDTO(block))
-            .position(blockContentUpdateDTO.getPosition())
-            .updated_by(block.getUpdated_by())
-            .build();
+        return block;
     }
 
     @Override
-    public BlockDeleteResponseDTO deleteBlock(BlockDeleteRequestDTO blockDeleteDTO, Long postId) {
+    public Block deleteBlock(BlockDeleteRequestDTO blockDeleteDTO, Long postId) {
         // 블록 삭제 로직 후 ResponseDTO로 전송
         Block block = blockRepository.findById(new ObjectId(blockDeleteDTO.getBlockId())).orElseThrow(
                 () -> new ApiException(ErrorStatus._BLOCK_NOT_FOUND)
         );
 
-        List<String> blockList = articlesCommandService.deleteBlockFromBlockList(postId, block);
+        blockRepository.delete(block);
 
-        return BlockDeleteResponseDTO.builder()
-            .blockId(block.getId().toString())
-            .blockList(blockList)
-            .build();
+        return block;
     }
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/block/service/BlockCommandServiceImpl.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/block/service/BlockCommandServiceImpl.java
@@ -53,7 +53,7 @@ public class BlockCommandServiceImpl implements BlockCommandService{
     }
 
     @Override
-    public Block updateBlock(BlockContentUpdateRequestDTO blockContentUpdateDTO, Long postId) {
+    public Block updateBlock(BlockContentUpdateRequestDTO blockContentUpdateDTO) {
         // 블록 업데이트 로직 후 ResponseDTO로 전송
         Block block = blockRepository.findById(new ObjectId(blockContentUpdateDTO.getBlockId())).orElseThrow(
                 () -> new ApiException(ErrorStatus._BLOCK_NOT_FOUND)
@@ -73,9 +73,9 @@ public class BlockCommandServiceImpl implements BlockCommandService{
     }
 
     @Override
-    public Block deleteBlock(BlockDeleteRequestDTO blockDeleteDTO, Long postId) {
+    public Block deleteBlock(String blockID) {
         // 블록 삭제 로직 후 ResponseDTO로 전송
-        Block block = blockRepository.findById(new ObjectId(blockDeleteDTO.getBlockId())).orElseThrow(
+        Block block = blockRepository.findById(new ObjectId(blockID)).orElseThrow(
                 () -> new ApiException(ErrorStatus._BLOCK_NOT_FOUND)
         );
 

--- a/article-service/src/main/java/com/newcord/articleservice/domain/block/service/BlockComposeService.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/block/service/BlockComposeService.java
@@ -8,8 +8,8 @@ import com.newcord.articleservice.domain.block.dto.BlockResponse.BlockCreateResp
 import com.newcord.articleservice.domain.block.dto.BlockResponse.BlockDeleteResponseDTO;
 
 public interface BlockComposeService {
-    BlockCreateResponseDTO createBlock(BlockCreateRequestDTO blockCreateDTO, Long postId);        // 블럭 생성
-    BlockContentUpdateResponseDTO updateBlock(BlockContentUpdateRequestDTO blockContentUpdateDTO, Long postId);        // 블럭 내용 수정
-    BlockDeleteResponseDTO deleteBlock(BlockDeleteRequestDTO blockDeleteDTO, Long postId);        // 블럭 삭제
+    BlockCreateResponseDTO createBlock(String userID, BlockCreateRequestDTO blockCreateDTO, Long postId);        // 블럭 생성
+    BlockContentUpdateResponseDTO updateBlock(String userID, BlockContentUpdateRequestDTO blockContentUpdateDTO, Long postId);        // 블럭 내용 수정
+    BlockDeleteResponseDTO deleteBlock(String userID, BlockDeleteRequestDTO blockDeleteDTO, Long postId);        // 블럭 삭제
 
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/block/service/BlockComposeService.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/block/service/BlockComposeService.java
@@ -1,18 +1,15 @@
 package com.newcord.articleservice.domain.block.service;
 
-import com.fasterxml.jackson.databind.util.JSONPObject;
 import com.newcord.articleservice.domain.block.dto.BlockRequest.BlockContentUpdateRequestDTO;
 import com.newcord.articleservice.domain.block.dto.BlockRequest.BlockCreateRequestDTO;
 import com.newcord.articleservice.domain.block.dto.BlockRequest.BlockDeleteRequestDTO;
 import com.newcord.articleservice.domain.block.dto.BlockResponse.BlockContentUpdateResponseDTO;
 import com.newcord.articleservice.domain.block.dto.BlockResponse.BlockCreateResponseDTO;
 import com.newcord.articleservice.domain.block.dto.BlockResponse.BlockDeleteResponseDTO;
-import com.newcord.articleservice.domain.block.entity.Block;
 
+public interface BlockComposeService {
+    BlockCreateResponseDTO createBlock(BlockCreateRequestDTO blockCreateDTO, Long postId);        // 블럭 생성
+    BlockContentUpdateResponseDTO updateBlock(BlockContentUpdateRequestDTO blockContentUpdateDTO, Long postId);        // 블럭 내용 수정
+    BlockDeleteResponseDTO deleteBlock(BlockDeleteRequestDTO blockDeleteDTO, Long postId);        // 블럭 삭제
 
-// Block도메인에 대한 command 모듈 서비스이다. 저수준의 인터페이스 계층을 구현한다.
-public interface BlockCommandService {
-    Block createBlock(BlockCreateRequestDTO blockCreateDTO, Long postId);        // 블럭 생성
-    Block updateBlock(BlockContentUpdateRequestDTO blockContentUpdateDTO, Long postId);        // 블럭 내용 수정
-    Block deleteBlock(BlockDeleteRequestDTO blockDeleteDTO, Long postId);        // 블럭 삭제
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/block/service/BlockComposeServiceImpl.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/block/service/BlockComposeServiceImpl.java
@@ -1,0 +1,34 @@
+package com.newcord.articleservice.domain.block.service;
+
+import com.newcord.articleservice.domain.block.dto.BlockRequest.BlockContentUpdateRequestDTO;
+import com.newcord.articleservice.domain.block.dto.BlockRequest.BlockCreateRequestDTO;
+import com.newcord.articleservice.domain.block.dto.BlockRequest.BlockDeleteRequestDTO;
+import com.newcord.articleservice.domain.block.dto.BlockResponse.BlockContentUpdateResponseDTO;
+import com.newcord.articleservice.domain.block.dto.BlockResponse.BlockCreateResponseDTO;
+import com.newcord.articleservice.domain.block.dto.BlockResponse.BlockDeleteResponseDTO;
+
+public class BlockComposeServiceImpl implements BlockComposeService{
+
+    @Override
+    public BlockCreateResponseDTO createBlock(BlockCreateRequestDTO blockCreateDTO, Long postId) {
+        //block 생성
+
+        // Article의 blockList에 block 추가
+        return null;
+    }
+
+    @Override
+    public BlockContentUpdateResponseDTO updateBlock(
+        BlockContentUpdateRequestDTO blockContentUpdateDTO, Long postId) {
+        // block update
+
+        return null;
+    }
+
+    @Override
+    public BlockDeleteResponseDTO deleteBlock(BlockDeleteRequestDTO blockDeleteDTO, Long postId) {
+        // 블럭 삭제
+        // Article의 blockList에서 block 삭제
+        return null;
+    }
+}

--- a/article-service/src/main/java/com/newcord/articleservice/domain/block/service/BlockComposeServiceImpl.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/block/service/BlockComposeServiceImpl.java
@@ -1,34 +1,79 @@
 package com.newcord.articleservice.domain.block.service;
 
+import com.newcord.articleservice.domain.articles.dto.ArticleRequest.InsertBlockRequestDTO;
+import com.newcord.articleservice.domain.articles.entity.Article;
+import com.newcord.articleservice.domain.articles.service.ArticlesCommandService;
 import com.newcord.articleservice.domain.block.dto.BlockRequest.BlockContentUpdateRequestDTO;
 import com.newcord.articleservice.domain.block.dto.BlockRequest.BlockCreateRequestDTO;
 import com.newcord.articleservice.domain.block.dto.BlockRequest.BlockDeleteRequestDTO;
 import com.newcord.articleservice.domain.block.dto.BlockResponse.BlockContentUpdateResponseDTO;
 import com.newcord.articleservice.domain.block.dto.BlockResponse.BlockCreateResponseDTO;
+import com.newcord.articleservice.domain.block.dto.BlockResponse.BlockDTO;
 import com.newcord.articleservice.domain.block.dto.BlockResponse.BlockDeleteResponseDTO;
+import com.newcord.articleservice.domain.block.entity.Block;
+import com.newcord.articleservice.domain.block.entity.BlockUpdatedBy;
+import com.newcord.articleservice.domain.editor.service.EditorQueryService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
+@Service
+@RequiredArgsConstructor
 public class BlockComposeServiceImpl implements BlockComposeService{
+    private final BlockCommandService blockCommandService;
+    private final EditorQueryService editorQueryService;
+    private final ArticlesCommandService articlesCommandService;
 
     @Override
-    public BlockCreateResponseDTO createBlock(BlockCreateRequestDTO blockCreateDTO, Long postId) {
+    public BlockCreateResponseDTO createBlock(String userID, BlockCreateRequestDTO blockCreateDTO, Long postId) {
+        //권한 확인
+        editorQueryService.getEditorByPostIdAndUserID(postId, userID);
+
         //block 생성
+        Block block = blockCommandService.createBlock(blockCreateDTO, postId);
 
         // Article의 blockList에 block 추가
-        return null;
+        Article article = articlesCommandService.insertBlock(postId, InsertBlockRequestDTO.builder()
+                .block(block)
+                .position(blockCreateDTO.getPosition())
+            .build());
+
+        return BlockCreateResponseDTO.builder()
+            .articleId(postId)
+            .blockDTO(BlockDTO.toDTO(block))
+            .position(blockCreateDTO.getPosition())
+            .blockList(article.getBlock_list())
+            .build();
     }
 
     @Override
-    public BlockContentUpdateResponseDTO updateBlock(
+    public BlockContentUpdateResponseDTO updateBlock(String userID,
         BlockContentUpdateRequestDTO blockContentUpdateDTO, Long postId) {
-        // block update
+        // 권한 확인
+        editorQueryService.getEditorByPostIdAndUserID(postId, userID);
 
-        return null;
+        Block block = blockCommandService.updateBlock(blockContentUpdateDTO);
+
+        return BlockContentUpdateResponseDTO.builder()
+            .blockDTO(BlockDTO.toDTO(block))
+            .updated_by(block.getUpdated_by())
+            .build();
     }
 
     @Override
-    public BlockDeleteResponseDTO deleteBlock(BlockDeleteRequestDTO blockDeleteDTO, Long postId) {
+    public BlockDeleteResponseDTO deleteBlock(String userID, BlockDeleteRequestDTO blockDeleteDTO, Long postId) {
+        // 권한 확인
+        editorQueryService.getEditorByPostIdAndUserID(postId, userID);
+
         // 블럭 삭제
+        Block block = blockCommandService.deleteBlock(blockDeleteDTO.getBlockId());
+
         // Article의 blockList에서 block 삭제
-        return null;
+        Article article = articlesCommandService.deleteBlockFromBlockList(postId, block);
+
+        return BlockDeleteResponseDTO.builder()
+            .blockId(block.getId().toString())
+            .blockList(article.getBlock_list())
+            .build();
     }
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/editor/controller/EditorController.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/editor/controller/EditorController.java
@@ -7,6 +7,7 @@ import com.newcord.articleservice.domain.editor.dto.EditorResponse.DeleteEditorR
 import com.newcord.articleservice.domain.editor.dto.EditorResponse.EditorAddResponseDTO;
 import com.newcord.articleservice.domain.editor.dto.EditorResponse.EditorListResponseDTO;
 import com.newcord.articleservice.domain.editor.service.EditorCommandService;
+import com.newcord.articleservice.domain.editor.service.EditorComposeService;
 import com.newcord.articleservice.domain.editor.service.EditorQueryService;
 import com.newcord.articleservice.domain.posts.Service.PostsCommandService;
 import com.newcord.articleservice.global.common.response.ApiResponse;
@@ -26,25 +27,20 @@ import org.springframework.web.bind.annotation.RestController;
 @AllArgsConstructor
 @RequestMapping("/editor")
 public class EditorController {
-    private final EditorCommandService editorCommandService;
+    private final EditorComposeService editorComposeService;
     private final EditorQueryService editorQueryService;
-    private final PostsCommandService postsCommandService;
 
     @Operation(summary = "편집자 삭제 API", description = "게시글 편집자 목록에서 입력받은 유저를 삭제합니다. 본인 삭제 외에 다른 유저 삭제용으로도 사용 가능합니다.")
     @DeleteMapping("/deleteUser")
     public ApiResponse<DeleteEditorResponseDTO> deleteUser(@RequestBody DeleteEditorRequestDTO deleteEditorRequestDTO) {
-        DeleteEditorResponseDTO response = editorCommandService.deleteEditor("testID", deleteEditorRequestDTO);
-        if(response.isPostDelete()){
-            postsCommandService.deletePost(deleteEditorRequestDTO.getPostId());
-        }
 
-        return ApiResponse.onSuccess(response);
+        return ApiResponse.onSuccess(editorComposeService.deleteEditor("testID", deleteEditorRequestDTO));
     }
 
     @Operation(summary = "편집자 추가 API", description = "게시글 편집자 목록에 입력받은 유저를 추가합니다. 공동작업자 초대할때 사용합니다.")
     @PostMapping("/addUser")
     public ApiResponse<EditorAddResponseDTO> addEditor(@RequestBody EditorAddRequestDTO addRequestDTO) {
-        return ApiResponse.onSuccess(editorCommandService.addEditor("testID", addRequestDTO));
+        return ApiResponse.onSuccess(editorComposeService.addEditor("testID", addRequestDTO));
     }
 
     @Operation(summary = "공동작업자 조회 API", description = "게시글의 공동작업자 목록을 조회합니다.")

--- a/article-service/src/main/java/com/newcord/articleservice/domain/editor/service/EditorCommandService.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/editor/service/EditorCommandService.java
@@ -2,13 +2,10 @@ package com.newcord.articleservice.domain.editor.service;
 
 import com.newcord.articleservice.domain.editor.dto.EditorRequest.DeleteEditorRequestDTO;
 import com.newcord.articleservice.domain.editor.dto.EditorRequest.EditorAddRequestDTO;
-import com.newcord.articleservice.domain.editor.dto.EditorResponse.DeleteEditorResponseDTO;
-import com.newcord.articleservice.domain.editor.dto.EditorResponse.EditorAddResponseDTO;
 import com.newcord.articleservice.domain.editor.entity.Editor;
 import com.newcord.articleservice.domain.posts.entity.Posts;
 
 public interface EditorCommandService {
-    Editor addEditor(String userID, Posts post, EditorAddRequestDTO editorAddDTO);       //편집자 추가
-    Editor addInitialEditor(Posts post,EditorAddRequestDTO editorAddDTO); //초기 편집자 추가 (게시글 생성시 사용, 요청자 검증 없음)
-    Editor deleteEditor(String userID, DeleteEditorRequestDTO deleteEditorRequestDTO);       //편집자 삭제
+    Editor addEditor(Posts post,EditorAddRequestDTO editorAddDTO); //초기 편집자 추가 (게시글 생성시 사용, 요청자 검증 없음)
+    Editor deleteEditor(DeleteEditorRequestDTO deleteEditorRequestDTO);       //편집자 삭제
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/editor/service/EditorCommandService.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/editor/service/EditorCommandService.java
@@ -4,9 +4,11 @@ import com.newcord.articleservice.domain.editor.dto.EditorRequest.DeleteEditorRe
 import com.newcord.articleservice.domain.editor.dto.EditorRequest.EditorAddRequestDTO;
 import com.newcord.articleservice.domain.editor.dto.EditorResponse.DeleteEditorResponseDTO;
 import com.newcord.articleservice.domain.editor.dto.EditorResponse.EditorAddResponseDTO;
+import com.newcord.articleservice.domain.editor.entity.Editor;
+import com.newcord.articleservice.domain.posts.entity.Posts;
 
 public interface EditorCommandService {
-    EditorAddResponseDTO addEditor(String userID, EditorAddRequestDTO editorAddDTO);       //편집자 추가
-    EditorAddResponseDTO addInitialEditor(EditorAddRequestDTO editorAddDTO); //초기 편집자 추가 (게시글 생성시 사용, 요청자 검증 없음)
-    DeleteEditorResponseDTO deleteEditor(String userID, DeleteEditorRequestDTO deleteEditorRequestDTO);       //편집자 삭제
+    Editor addEditor(String userID, Posts post, EditorAddRequestDTO editorAddDTO);       //편집자 추가
+    Editor addInitialEditor(Posts post,EditorAddRequestDTO editorAddDTO); //초기 편집자 추가 (게시글 생성시 사용, 요청자 검증 없음)
+    Editor deleteEditor(String userID, DeleteEditorRequestDTO deleteEditorRequestDTO);       //편집자 삭제
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/editor/service/EditorCommandServiceImpl.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/editor/service/EditorCommandServiceImpl.java
@@ -19,52 +19,43 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class EditorCommandServiceImpl implements EditorCommandService {
     private final EditorRepository editorRepository;
-    private final EditorQueryService editorQueryService;
-    private final PostsQueryService postsQueryService;
 
     @Override
-    public EditorAddResponseDTO addEditor(String userID, EditorAddRequestDTO editorAddDTO) {
+    public Editor addEditor(String userID, Posts post, EditorAddRequestDTO editorAddDTO) {
         // 요청 유저의 권한 확인
-        editorQueryService.getEditorByPostIdAndUserID(editorAddDTO.getPostId(), userID);
+        editorRepository.findByPostIdAndUserID(editorAddDTO.getPostId(), userID)
+            .ifPresent(a -> {
+                throw new ApiException(ErrorStatus._EDITOR_NOT_FOUND);
+            });
 
-        return addInitialEditor(editorAddDTO);
+        return addInitialEditor(post, editorAddDTO);
     }
 
     @Override
-    public EditorAddResponseDTO addInitialEditor(EditorAddRequestDTO editorAddDTO) {
-        // 게시글 존재 확인
-        Posts post = postsQueryService.getPost(editorAddDTO.getPostId());
-
+    public Editor addInitialEditor(Posts post, EditorAddRequestDTO editorAddDTO) {
         Editor editor = Editor.builder()
             .post(post)
             .userID(editorAddDTO.getUserID())
             .build();
         editorRepository.save(editor);
 
-        return EditorAddResponseDTO.builder()
-            .userID(editor.getUserID())
-            .postId(editor.getPost().getId())
-            .build();
+        return editor;
     }
 
     @Override
-    public DeleteEditorResponseDTO deleteEditor(String userID, DeleteEditorRequestDTO deleteEditorRequestDTO) {
+    public Editor deleteEditor(String userID, DeleteEditorRequestDTO deleteEditorRequestDTO) {
         // 요청한 유저의 권한 확인
-        editorQueryService.getEditorByPostIdAndUserID(deleteEditorRequestDTO.getPostId(), userID);
-        Editor deleteEditor = editorQueryService.getEditorByPostIdAndUserID(deleteEditorRequestDTO.getPostId(), deleteEditorRequestDTO.getUserID());
+        editorRepository.findByPostIdAndUserID(deleteEditorRequestDTO.getPostId(), userID)
+            .ifPresent(a -> {
+                throw new ApiException(ErrorStatus._EDITOR_NOT_FOUND);
+            });
+
+        // 삭제할 편집자 조회
+        Editor deleteEditor = editorRepository.findByPostIdAndUserID(deleteEditorRequestDTO.getPostId(), deleteEditorRequestDTO.getUserID())
+            .orElseThrow(() -> new ApiException(ErrorStatus._EDITOR_NOT_FOUND));
 
         editorRepository.delete(deleteEditor);
-
-        DeleteEditorResponseDTO deleteEditorResponseDTO = DeleteEditorResponseDTO.builder()
-                .userID(deleteEditor.getUserID())
-                .postId(deleteEditor.getPost().getId())
-                .build();
-
-        List<Editor> editorList = editorRepository.findByPostId(deleteEditorRequestDTO.getPostId());
-        if(editorList.isEmpty()) {
-            deleteEditorResponseDTO.setPostDelete(true);
-        }
-
-        return deleteEditorResponseDTO;
+        
+        return deleteEditor;
     }
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/editor/service/EditorCommandServiceImpl.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/editor/service/EditorCommandServiceImpl.java
@@ -2,16 +2,11 @@ package com.newcord.articleservice.domain.editor.service;
 
 import com.newcord.articleservice.domain.editor.dto.EditorRequest.DeleteEditorRequestDTO;
 import com.newcord.articleservice.domain.editor.dto.EditorRequest.EditorAddRequestDTO;
-import com.newcord.articleservice.domain.editor.dto.EditorResponse.DeleteEditorResponseDTO;
-import com.newcord.articleservice.domain.editor.dto.EditorResponse.EditorAddResponseDTO;
 import com.newcord.articleservice.domain.editor.entity.Editor;
 import com.newcord.articleservice.domain.editor.repository.EditorRepository;
-import com.newcord.articleservice.domain.posts.Service.PostsCommandService;
-import com.newcord.articleservice.domain.posts.Service.PostsQueryService;
 import com.newcord.articleservice.domain.posts.entity.Posts;
 import com.newcord.articleservice.global.common.exception.ApiException;
 import com.newcord.articleservice.global.common.response.code.status.ErrorStatus;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,18 +16,7 @@ public class EditorCommandServiceImpl implements EditorCommandService {
     private final EditorRepository editorRepository;
 
     @Override
-    public Editor addEditor(String userID, Posts post, EditorAddRequestDTO editorAddDTO) {
-        // 요청 유저의 권한 확인
-        editorRepository.findByPostIdAndUserID(editorAddDTO.getPostId(), userID)
-            .ifPresent(a -> {
-                throw new ApiException(ErrorStatus._EDITOR_NOT_FOUND);
-            });
-
-        return addInitialEditor(post, editorAddDTO);
-    }
-
-    @Override
-    public Editor addInitialEditor(Posts post, EditorAddRequestDTO editorAddDTO) {
+    public Editor addEditor(Posts post, EditorAddRequestDTO editorAddDTO) {
         Editor editor = Editor.builder()
             .post(post)
             .userID(editorAddDTO.getUserID())
@@ -43,19 +27,13 @@ public class EditorCommandServiceImpl implements EditorCommandService {
     }
 
     @Override
-    public Editor deleteEditor(String userID, DeleteEditorRequestDTO deleteEditorRequestDTO) {
-        // 요청한 유저의 권한 확인
-        editorRepository.findByPostIdAndUserID(deleteEditorRequestDTO.getPostId(), userID)
-            .ifPresent(a -> {
-                throw new ApiException(ErrorStatus._EDITOR_NOT_FOUND);
-            });
-
+    public Editor deleteEditor(DeleteEditorRequestDTO deleteEditorRequestDTO) {
         // 삭제할 편집자 조회
         Editor deleteEditor = editorRepository.findByPostIdAndUserID(deleteEditorRequestDTO.getPostId(), deleteEditorRequestDTO.getUserID())
             .orElseThrow(() -> new ApiException(ErrorStatus._EDITOR_NOT_FOUND));
 
         editorRepository.delete(deleteEditor);
-        
+
         return deleteEditor;
     }
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/editor/service/EditorComposeService.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/editor/service/EditorComposeService.java
@@ -7,6 +7,5 @@ import com.newcord.articleservice.domain.editor.dto.EditorResponse.EditorAddResp
 
 public interface EditorComposeService {
     EditorAddResponseDTO addEditor(String userID, EditorAddRequestDTO editorAddDTO);       //편집자 추가
-    EditorAddResponseDTO addInitialEditor(EditorAddRequestDTO editorAddDTO); //초기 편집자 추가 (게시글 생성시 사용, 요청자 검증 없음)
     DeleteEditorResponseDTO deleteEditor(String userID, DeleteEditorRequestDTO deleteEditorRequestDTO);       //편집자 삭제
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/editor/service/EditorComposeService.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/editor/service/EditorComposeService.java
@@ -1,0 +1,12 @@
+package com.newcord.articleservice.domain.editor.service;
+
+import com.newcord.articleservice.domain.editor.dto.EditorRequest.DeleteEditorRequestDTO;
+import com.newcord.articleservice.domain.editor.dto.EditorRequest.EditorAddRequestDTO;
+import com.newcord.articleservice.domain.editor.dto.EditorResponse.DeleteEditorResponseDTO;
+import com.newcord.articleservice.domain.editor.dto.EditorResponse.EditorAddResponseDTO;
+
+public interface EditorComposeService {
+    EditorAddResponseDTO addEditor(String userID, EditorAddRequestDTO editorAddDTO);       //편집자 추가
+    EditorAddResponseDTO addInitialEditor(EditorAddRequestDTO editorAddDTO); //초기 편집자 추가 (게시글 생성시 사용, 요청자 검증 없음)
+    DeleteEditorResponseDTO deleteEditor(String userID, DeleteEditorRequestDTO deleteEditorRequestDTO);       //편집자 삭제
+}

--- a/article-service/src/main/java/com/newcord/articleservice/domain/editor/service/EditorComposeServiceImpl.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/editor/service/EditorComposeServiceImpl.java
@@ -1,41 +1,83 @@
 package com.newcord.articleservice.domain.editor.service;
 
+import com.newcord.articleservice.domain.articles.entity.Article;
+import com.newcord.articleservice.domain.articles.service.ArticlesCommandService;
+import com.newcord.articleservice.domain.block.service.BlockCommandService;
 import com.newcord.articleservice.domain.editor.dto.EditorRequest.DeleteEditorRequestDTO;
 import com.newcord.articleservice.domain.editor.dto.EditorRequest.EditorAddRequestDTO;
 import com.newcord.articleservice.domain.editor.dto.EditorResponse.DeleteEditorResponseDTO;
 import com.newcord.articleservice.domain.editor.dto.EditorResponse.EditorAddResponseDTO;
 import com.newcord.articleservice.domain.editor.entity.Editor;
+import com.newcord.articleservice.domain.editor.repository.EditorRepository;
+import com.newcord.articleservice.domain.posts.Service.PostsCommandService;
+import com.newcord.articleservice.domain.posts.Service.PostsQueryService;
+import com.newcord.articleservice.domain.posts.entity.Posts;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
+@Service
+@RequiredArgsConstructor
 public class EditorComposeServiceImpl implements EditorComposeService{
+    private final EditorCommandService editorCommandService;
+    private final EditorQueryService editorQueryService;
+    private final PostsCommandService postsCommandService;
+    private final PostsQueryService postsQueryService;
+    private final ArticlesCommandService articlesCommandService;
+    private final BlockCommandService blockCommandService;
+
+
+    private final EditorRepository editorRepository;
 
     @Override
     public EditorAddResponseDTO addEditor(String userID, EditorAddRequestDTO editorAddDTO) {
-        return null;
-    }
+        // 권한 확인
+        editorQueryService.getEditorByPostIdAndUserID(editorAddDTO.getPostId(), userID);
 
-    @Override
-    public EditorAddResponseDTO addInitialEditor(EditorAddRequestDTO editorAddDTO) {
-        return null;
+        // 게시글 조회
+        Posts posts = postsQueryService.getPost(editorAddDTO.getPostId());
+
+        // 에디터 추가
+        Editor newEditor = editorCommandService.addEditor(posts, editorAddDTO);
+
+        return EditorAddResponseDTO.builder()
+            .postId(newEditor.getPost().getId())
+            .userID(newEditor.getUserID())
+            .build();
     }
 
     @Override
     public DeleteEditorResponseDTO deleteEditor(String userID,
         DeleteEditorRequestDTO deleteEditorRequestDTO) {
+        // 권한 확인
+        editorQueryService.getEditorByPostIdAndUserID(deleteEditorRequestDTO.getPostId(), userID);
+
         // 에디터 삭제
+        Editor deleteEditor = editorCommandService.deleteEditor(deleteEditorRequestDTO);
+
+        DeleteEditorResponseDTO deleteEditorResponseDTO = DeleteEditorResponseDTO.builder()
+            .postId(deleteEditor.getPost().getId())
+            .userID(deleteEditor.getUserID())
+            .build();
 
         // 게시글에 대한 에디터 리스트 조회
-
         // 에디터가 존재하지 않으면 게시글 완전 삭제
+        // input DB 조회 (CDC오차를 고려하여 output DB가 아닌 input DB를 조회함)
+        List<Editor> editorList = editorRepository.findByPostId(deleteEditorRequestDTO.getPostId());
+        if(editorList.isEmpty()) {
+            deleteEditorResponseDTO.setPostDelete(true);
+        }
 
-        // input DB 조회 (CDC오차를 고려하여 output DB가 아닌 input DB를 조회함
-//        List<Editor> editorList = editorRepository.findByPostId(deleteEditorRequestDTO.getPostId());
-//        if(editorList.isEmpty()) {
-//            deleteEditorResponseDTO.setPostDelete(true);
-//        }
+        // 관련 엔티티 삭제
+        if(deleteEditorResponseDTO.isPostDelete()) {
+            Article aritcle = articlesCommandService.deleteArticle(deleteEditorRequestDTO.getPostId());
+            for (String blockId : aritcle.getBlock_list()) {
+                blockCommandService.deleteBlock(blockId);
+            }
+            postsCommandService.deletePost(deleteEditorRequestDTO.getPostId());
+        }
 
 
-
-        return null;
+        return deleteEditorResponseDTO;
     }
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/editor/service/EditorComposeServiceImpl.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/editor/service/EditorComposeServiceImpl.java
@@ -1,0 +1,41 @@
+package com.newcord.articleservice.domain.editor.service;
+
+import com.newcord.articleservice.domain.editor.dto.EditorRequest.DeleteEditorRequestDTO;
+import com.newcord.articleservice.domain.editor.dto.EditorRequest.EditorAddRequestDTO;
+import com.newcord.articleservice.domain.editor.dto.EditorResponse.DeleteEditorResponseDTO;
+import com.newcord.articleservice.domain.editor.dto.EditorResponse.EditorAddResponseDTO;
+import com.newcord.articleservice.domain.editor.entity.Editor;
+import java.util.List;
+
+public class EditorComposeServiceImpl implements EditorComposeService{
+
+    @Override
+    public EditorAddResponseDTO addEditor(String userID, EditorAddRequestDTO editorAddDTO) {
+        return null;
+    }
+
+    @Override
+    public EditorAddResponseDTO addInitialEditor(EditorAddRequestDTO editorAddDTO) {
+        return null;
+    }
+
+    @Override
+    public DeleteEditorResponseDTO deleteEditor(String userID,
+        DeleteEditorRequestDTO deleteEditorRequestDTO) {
+        // 에디터 삭제
+
+        // 게시글에 대한 에디터 리스트 조회
+
+        // 에디터가 존재하지 않으면 게시글 완전 삭제
+
+        // input DB 조회 (CDC오차를 고려하여 output DB가 아닌 input DB를 조회함
+//        List<Editor> editorList = editorRepository.findByPostId(deleteEditorRequestDTO.getPostId());
+//        if(editorList.isEmpty()) {
+//            deleteEditorResponseDTO.setPostDelete(true);
+//        }
+
+
+
+        return null;
+    }
+}

--- a/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsComposeService.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsComposeService.java
@@ -5,9 +5,11 @@ import com.newcord.articleservice.domain.posts.dto.PostRequest.PostUpdateRequest
 import com.newcord.articleservice.domain.posts.dto.PostResponse.PostCreateResponseDTO;
 import com.newcord.articleservice.domain.posts.entity.Posts;
 
-public interface PostsCommandService {
-
-    Posts createPost(String userID, PostCreateRequestDTO postCreateDTO);        //게시글 생성
+public interface PostsComposeService {
+    PostCreateResponseDTO createPost(String userID, PostCreateRequestDTO postCreateDTO);        //게시글 생성
     Posts updatePost(String userID, PostUpdateRequestDTO postUpdateDTO);        //게시글 수정
     void deletePost(Long postId);        //게시글 삭제 (편집자 검증을 거치지 않음)
+    String createPostEditSession(String articleID);        //게시글 편집 세션 생성
+    String deletePostEditSession(String articleID);        //게시글 편집 세션 삭제
+
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsComposeService.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsComposeService.java
@@ -8,7 +8,6 @@ import com.newcord.articleservice.domain.posts.entity.Posts;
 public interface PostsComposeService {
     PostCreateResponseDTO createPost(String userID, PostCreateRequestDTO postCreateDTO);        //게시글 생성
     Posts updatePost(String userID, PostUpdateRequestDTO postUpdateDTO);        //게시글 수정
-    void deletePost(Long postId);        //게시글 삭제 (편집자 검증을 거치지 않음)
     String createPostEditSession(String articleID);        //게시글 편집 세션 생성
     String deletePostEditSession(String articleID);        //게시글 편집 세션 삭제
 

--- a/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsComposeServiceImpl.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsComposeServiceImpl.java
@@ -1,51 +1,62 @@
 package com.newcord.articleservice.domain.posts.Service;
 
+import com.newcord.articleservice.domain.articles.service.ArticlesCommandService;
 import com.newcord.articleservice.domain.editor.dto.EditorRequest.EditorAddRequestDTO;
+import com.newcord.articleservice.domain.editor.service.EditorCommandService;
+import com.newcord.articleservice.domain.editor.service.EditorQueryService;
 import com.newcord.articleservice.domain.posts.dto.PostRequest.PostCreateRequestDTO;
 import com.newcord.articleservice.domain.posts.dto.PostRequest.PostUpdateRequestDTO;
 import com.newcord.articleservice.domain.posts.dto.PostResponse.PostCreateResponseDTO;
 import com.newcord.articleservice.domain.posts.entity.Posts;
+import com.newcord.articleservice.rabbitMQ.Service.RabbitMQService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
+@Service
+@RequiredArgsConstructor
 public class PostsComposeServiceImpl implements PostsComposeService{
+    private final PostsCommandService postsCommandService;
 
+    private final EditorCommandService editorCommandService;
+    private final EditorQueryService editorQueryService;
+
+    private final ArticlesCommandService articlesCommandService;
+
+    private final RabbitMQService rabbitMQService;
     @Override
     public PostCreateResponseDTO createPost(String userID, PostCreateRequestDTO postCreateDTO) {
+        Posts posts = postsCommandService.createPost(userID, postCreateDTO);
 
-//        editorCommandService.addInitialEditor(EditorAddRequestDTO.builder()
-//            .postId(newPosts.getId())
-//            .userID(userID)
-//            .build());
-//
-//
-//        articlesCommandService.createArticle(newPosts.getId());
-//
-//        return PostCreateResponseDTO.builder()
-//            .id(newPosts.getId())
-//            .build();
-        return null;
+        editorCommandService.addEditor(posts,EditorAddRequestDTO.builder()
+            .postId(posts.getId())
+            .userID(userID)
+            .build());
+
+        articlesCommandService.createArticle(posts.getId());
+
+        return PostCreateResponseDTO.builder()
+            .id(posts.getId())
+            .build();
     }
 
     @Override
     public Posts updatePost(String userID, PostUpdateRequestDTO postUpdateDTO) {
         // 요청 유저의 권한 확인
-//        editorQueryService.getEditorByPostIdAndUserID(postUpdateDTO.getId(), userID);
-        return null;
+        editorQueryService.getEditorByPostIdAndUserID(postUpdateDTO.getId(), userID);
+
+        return postsCommandService.updatePost(userID, postUpdateDTO);
     }
 
-    @Override
-    public void deletePost(Long postId) {
-//        articlesCommandService.deleteArticle(postId);
-    }
 
     @Override
     public String createPostEditSession(String articleID) {
-//        rabbitMQService.createFanoutExchange(articleID);
-        return null;
+        rabbitMQService.createFanoutExchange(articleID);
+        return "편집세션이 생성되었습니다.";
     }
 
     @Override
     public String deletePostEditSession(String articleID) {
-//        rabbitMQService.deleteTopic(articleID);
-        return null;
+        rabbitMQService.deleteTopic(articleID);
+        return "편집세션이 삭제되었습니다.";
     }
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsComposeServiceImpl.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsComposeServiceImpl.java
@@ -1,0 +1,51 @@
+package com.newcord.articleservice.domain.posts.Service;
+
+import com.newcord.articleservice.domain.editor.dto.EditorRequest.EditorAddRequestDTO;
+import com.newcord.articleservice.domain.posts.dto.PostRequest.PostCreateRequestDTO;
+import com.newcord.articleservice.domain.posts.dto.PostRequest.PostUpdateRequestDTO;
+import com.newcord.articleservice.domain.posts.dto.PostResponse.PostCreateResponseDTO;
+import com.newcord.articleservice.domain.posts.entity.Posts;
+
+public class PostsComposeServiceImpl implements PostsComposeService{
+
+    @Override
+    public PostCreateResponseDTO createPost(String userID, PostCreateRequestDTO postCreateDTO) {
+
+//        editorCommandService.addInitialEditor(EditorAddRequestDTO.builder()
+//            .postId(newPosts.getId())
+//            .userID(userID)
+//            .build());
+//
+//
+//        articlesCommandService.createArticle(newPosts.getId());
+//
+//        return PostCreateResponseDTO.builder()
+//            .id(newPosts.getId())
+//            .build();
+        return null;
+    }
+
+    @Override
+    public Posts updatePost(String userID, PostUpdateRequestDTO postUpdateDTO) {
+        // 요청 유저의 권한 확인
+//        editorQueryService.getEditorByPostIdAndUserID(postUpdateDTO.getId(), userID);
+        return null;
+    }
+
+    @Override
+    public void deletePost(Long postId) {
+//        articlesCommandService.deleteArticle(postId);
+    }
+
+    @Override
+    public String createPostEditSession(String articleID) {
+//        rabbitMQService.createFanoutExchange(articleID);
+        return null;
+    }
+
+    @Override
+    public String deletePostEditSession(String articleID) {
+//        rabbitMQService.deleteTopic(articleID);
+        return null;
+    }
+}

--- a/article-service/src/main/java/com/newcord/articleservice/domain/posts/controller/PostsController.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/posts/controller/PostsController.java
@@ -2,6 +2,7 @@ package com.newcord.articleservice.domain.posts.controller;
 
 import com.newcord.articleservice.domain.editor.service.EditorQueryService;
 import com.newcord.articleservice.domain.posts.Service.PostsCommandService;
+import com.newcord.articleservice.domain.posts.Service.PostsComposeService;
 import com.newcord.articleservice.domain.posts.Service.PostsQueryService;
 import com.newcord.articleservice.domain.posts.dto.PostRequest.PostCreateRequestDTO;
 import com.newcord.articleservice.domain.posts.dto.PostRequest.PostUpdateRequestDTO;
@@ -26,26 +27,26 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/posts")
 public class PostsController {
-    private final PostsCommandService postsCommandService;
+    private final PostsComposeService postsComposeService;
     private final PostsQueryService postsQueryService;
     private final EditorQueryService editorQueryService;
 
     @Operation(summary = "게시글 편집 세션 생성", description = "게시글 편집 세션을 생성합니다.")
     @PostMapping("/createEditSession")
     public ApiResponse<String> createPostEditSession(@RequestBody String articleID) {
-        return ApiResponse.onSuccess(postsCommandService.createPostEditSession(articleID));
+        return ApiResponse.onSuccess(postsComposeService.createPostEditSession(articleID));
     }
 
     @Operation(summary = "게시글 편집 세션 삭제", description = "게시글 편집 세션을 삭제합니다.")
     @PostMapping("/deleteEditSession")
     public ApiResponse<String> deletePostEditSession(@RequestBody String articleID) {
-        return ApiResponse.onSuccess(postsCommandService.deletePostEditSession(articleID));
+        return ApiResponse.onSuccess(postsComposeService.deletePostEditSession(articleID));
     }
 
     @Operation(summary = "게시글 생성", description = "게시글을 생성합니다.")
     @PostMapping("/createPost")
     public ApiResponse<PostCreateResponseDTO> createPost(@RequestBody PostCreateRequestDTO postCreateRequestDTO) {
-        return ApiResponse.onSuccess(postsCommandService.createPost("testID", postCreateRequestDTO));
+        return ApiResponse.onSuccess(postsComposeService.createPost("testID", postCreateRequestDTO));
     }
 
     @Operation(summary = "게시글 조회", description = "게시글을 조회합니다.")
@@ -63,7 +64,7 @@ public class PostsController {
     @Operation(summary = "게시글 편집", description = "게시글을 편집합니다.")
     @PostMapping("/editPost")
     public ApiResponse<Posts> editPost(@RequestBody PostUpdateRequestDTO updateRequestDTO) {
-        return ApiResponse.onSuccess(postsCommandService.updatePost("testID", updateRequestDTO));
+        return ApiResponse.onSuccess(postsComposeService.updatePost("testID", updateRequestDTO));
     }
 
 }


### PR DESCRIPTION
# 요약
- 게시글서비스의 순환참조를 해결하기 위해 서비스를 모듈/컴포즈 서비스로 분할하였다.

# 변경사항
- 모든 도메인의 서비스를 Command/Query/Compose로 분할하였다.

# 결과
Swagger UI
- RestAPI 모두 테스트 해보았고 정상작동 확인했습니다.
![스크린샷 2024-05-11 오전 3 00 52](https://github.com/KEA-Kovengers/Backend/assets/32007781/9915f4ff-fd47-4f0f-9f31-9aba5731175b)
웹소켓 관련
- 웹소켓 관련도 모두 테스트하였고 정상작동 확인했습니다. 로그는 저장해두지 않아 따로 첨부는 못 했지만, DB에 저장된 내용을 첨부합니다.
Article collection
<img width="1544" alt="스크린샷 2024-05-11 오전 3 03 03" src="https://github.com/KEA-Kovengers/Backend/assets/32007781/5ba50f1e-de23-4f40-881a-367c1fc890d8">
Block collection
<img width="1544" alt="스크린샷 2024-05-11 오전 3 03 10" src="https://github.com/KEA-Kovengers/Backend/assets/32007781/2a44e5db-4880-490d-89b9-1f1a858740c8">

# 전달사항
어떻게 해결했는지, Command/Query/Compose각각의 의미는 컨플루언스에 정리해두었습니다. 지라 이슈에 링크 걸어놨으니 확인 바랍니다. 
컨플루언스를 읽고 리뷰해주시면 감사하겠습니다.
다른 서비스 파트 분들도 참고하고 코드에 반영하면 좋을거같습니다. 


# 이슈넘버
- JIRA 이슈 번호를 입력해주세요
