### PR TITLE
[FEAT] 게시글 조회 코드 수정, 유저 댓글 활동내역 조회

### DIFF
--- a/article-service/src/main/java/com/newcord/articleservice/domain/comments/controller/CommentsController.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/comments/controller/CommentsController.java
@@ -4,6 +4,7 @@ import com.newcord.articleservice.domain.comments.dto.CommentsRequest.*;
 import com.newcord.articleservice.domain.comments.dto.CommentsResponse;
 import com.newcord.articleservice.domain.comments.entity.Comments;
 import com.newcord.articleservice.domain.comments.service.CommentsCommandService;
+import com.newcord.articleservice.domain.comments.service.CommentsComposeService;
 import com.newcord.articleservice.domain.comments.service.CommentsQueryService;
 import com.newcord.articleservice.global.annotation.UserID;
 import com.newcord.articleservice.global.common.response.ApiResponse;
@@ -23,6 +24,7 @@ import java.util.List;
 @RequestMapping("/articles/comment")
 public class CommentsController {
 
+    private final CommentsComposeService commentsComposeService;
     private final CommentsCommandService commentsCommandService;
     private final CommentsQueryService commentsQueryService;
 
@@ -38,11 +40,16 @@ public class CommentsController {
         return ApiResponse.onSuccess(commentsCommandService.createComment(userID,commentsCreateRequestDTO));
     }
 
-    @GetMapping("/commentlist/{postid}")
+    @GetMapping("/userlist/{postid}")
     @Operation(summary = "게시글 댓글 보기", description = "게시글 댓글 보기")
     public ApiResponse<List<Comments>> getCommentsList(@PathVariable Long postid){
         return ApiResponse.onSuccess(commentsQueryService.getCommentsList(postid));
     }
 
 
+    @GetMapping("/commentlist/{userid}")
+    @Operation(summary = "유저의 댓글 내역 조회",description = "유저 활동페이지 댓글 목록 조회")
+    public ApiResponse<List<CommentsResponse.CommentsUserResponseDTO>> getUsersCommentsList(@PathVariable Long userid){
+        return ApiResponse.onSuccess(commentsComposeService.getUserCommentesList(userid));
+    }
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/comments/dto/CommentsResponse.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/comments/dto/CommentsResponse.java
@@ -1,9 +1,12 @@
 package com.newcord.articleservice.domain.comments.dto;
 
+import com.newcord.articleservice.domain.comments.entity.Comments;
+import com.newcord.articleservice.domain.posts.entity.Posts;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.parameters.P;
 
 public class CommentsResponse {
 
@@ -19,4 +22,27 @@ public class CommentsResponse {
         private String body;
         private Boolean isDeleted;
     }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class CommentsPostResponseDTO{
+        private Long id;
+        private Long commentID;
+        private Long userID;
+        private String body;
+        private Boolean isDeleted;
+        Posts posts;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class CommentsUserResponseDTO{
+        Comments comments;
+        Posts posts;
+    }
+
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/comments/repository/CommentsRepository.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/comments/repository/CommentsRepository.java
@@ -13,5 +13,7 @@ public interface CommentsRepository extends JpaRepository<Comments,Long> {
     @Query("SELECT c FROM Comments c WHERE c.postId =:postID")
     List<Comments> findByPostId(Long postID);
 
+    @Query("SELECT c FROM Comments c WHERE c.user_id =:userID")
+    List<Comments> findByUser_id(Long userID);
     //List<Comments> findByPostIdOrderByComment_idAsc(Long postId);
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/comments/service/CommentsComposeService.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/comments/service/CommentsComposeService.java
@@ -1,0 +1,9 @@
+package com.newcord.articleservice.domain.comments.service;
+
+import com.newcord.articleservice.domain.comments.dto.CommentsResponse;
+
+import java.util.List;
+
+public interface CommentsComposeService {
+    List<CommentsResponse.CommentsUserResponseDTO> getUserCommentesList(Long userid);
+}

--- a/article-service/src/main/java/com/newcord/articleservice/domain/comments/service/CommentsComposeServiceImpl.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/comments/service/CommentsComposeServiceImpl.java
@@ -1,0 +1,35 @@
+package com.newcord.articleservice.domain.comments.service;
+
+import com.newcord.articleservice.domain.comments.dto.CommentsResponse.*;
+import com.newcord.articleservice.domain.comments.entity.Comments;
+import com.newcord.articleservice.domain.posts.Service.PostsQueryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CommentsComposeServiceImpl implements CommentsComposeService{
+
+    private final CommentsQueryService commentsQueryService;
+    private final PostsQueryService postsQueryService;
+
+    @Override
+    public List<CommentsUserResponseDTO> getUserCommentesList(Long userid){
+        List<Comments> comments=commentsQueryService.getCommentUserid(userid);
+        List<CommentsUserResponseDTO> result=new ArrayList<>();
+
+        for(Comments comments1:comments){
+            CommentsUserResponseDTO commentsUserResponseDTO=CommentsUserResponseDTO.builder()
+                    .comments(comments1)
+                    .posts(postsQueryService.getPost(comments1.getPostId()))
+                    .build();
+            result.add(commentsUserResponseDTO);
+        }
+        return result;
+    }
+}

--- a/article-service/src/main/java/com/newcord/articleservice/domain/comments/service/CommentsQueryService.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/comments/service/CommentsQueryService.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface CommentsQueryService {
     List<Comments> getCommentsList(Long postID);
+
+    List<Comments> getCommentUserid(Long userid);
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/comments/service/CommentsQueryServiceImpl.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/comments/service/CommentsQueryServiceImpl.java
@@ -1,15 +1,12 @@
 package com.newcord.articleservice.domain.comments.service;
 
-import com.newcord.articleservice.domain.comments.dto.CommentsResponse.*;
 import com.newcord.articleservice.domain.comments.entity.Comments;
 import com.newcord.articleservice.domain.comments.repository.CommentsRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
@@ -26,5 +23,10 @@ public class CommentsQueryServiceImpl implements CommentsQueryService{
         List<Comments> comments = commentsRepository.findByPostId(postID);
         comments.sort(Comparator.comparing(Comments::getComment_id));
         return comments;
+    }
+
+    @Override
+    public List<Comments> getCommentUserid(Long userid){
+        return commentsRepository.findByUser_id(userid);
     }
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/editor/repository/EditorRepository.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/editor/repository/EditorRepository.java
@@ -3,6 +3,8 @@ package com.newcord.articleservice.domain.editor.repository;
 import com.newcord.articleservice.domain.editor.entity.Editor;
 import java.util.List;
 import java.util.Optional;
+
+import com.newcord.articleservice.domain.posts.enums.PostStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,7 +13,10 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface EditorRepository extends JpaRepository<Editor, Long> {
-    Page<Editor> findByUserID(Long userID, Pageable pageable);
+//    Page<Editor> findByUserID(Long userID, Pageable pageable);
+
+    @Query("SELECT c FROM Editor c WHERE c.userID =:userID and c.post.status =:postStatus")
+    Page<Editor> findByUserID(Long userID, PostStatus postStatus,Pageable pageable);
     Optional<Editor> findByPostIdAndUserID(Long postId, Long userID);
     List<Editor> findByPostId(Long postId);
     List<Editor> findAllByPostId(Long postId);

--- a/article-service/src/main/java/com/newcord/articleservice/domain/editor/service/EditorQueryServiceImpl.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/editor/service/EditorQueryServiceImpl.java
@@ -32,16 +32,21 @@ public class EditorQueryServiceImpl implements EditorQueryService{
     public PostListResponseDTO getPostListByUserID(Long userID, Integer page, Integer size) {
         PageRequest pageRequest = PageRequest.of(page, size);
 
-        Page<Editor> editors = editorRepository.findByUserID(userID, pageRequest);
-        List<Editor> filteredEditors = editors.getContent().stream()
-                .filter(editor -> editor.getPost().getStatus() == PostStatus.POST)
-                .collect(Collectors.toList());
+        Page<Editor> editors = editorRepository.findByUserID(userID,PostStatus.POST, pageRequest);
 
-        Page<Editor> filteredEditorsPage = new PageImpl<>(filteredEditors, pageRequest, filteredEditors.size());
 
         return PostListResponseDTO.builder()
-                .postList(filteredEditorsPage)
+                .postList(editors)
                 .build();
+//        Page<Editor> editors = editorRepository.findByUserID(userID,PostStatus.POST, pageRequest);
+//        List<Editor> filteredEditors = editors.getContent().stream()
+//                .collect(Collectors.toList());
+//
+//        Page<Editor> filteredEditorsPage = new PageImpl<>(filteredEditors, pageRequest, filteredEditors.size());
+//
+//        return PostListResponseDTO.builder()
+//                .postList(filteredEditorsPage)
+//                .build();
     }
 
     @Override

--- a/article-service/src/main/java/com/newcord/articleservice/domain/likes/controller/LikeController.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/likes/controller/LikeController.java
@@ -44,7 +44,7 @@ public class LikeController {
     }
 
     @GetMapping("/likelist/{userid}")
-    @Operation(summary = "좋아요 내역 조회",description = "좋아요 목록 조회")
+    @Operation(summary = "유저의 좋아요 내역 조회",description = "유저 활동페이지 좋아요 목록 조회")
     public ApiResponse<List<LikeResponse.LikeResponseDTO>> getLikeList(@PathVariable Long userid){
         return ApiResponse.onSuccess(likeComposeService.getLikeList(userid));
     }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsComposeService.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsComposeService.java
@@ -20,5 +20,5 @@ public interface PostsComposeService {
 
 
 
-    PostResponse.SocialPostListDTO getPostByHashTag(String TagName, Integer page, Integer size);
+   // PostResponse.SocialPostListDTO getPostByHashTag(String TagName, Integer page, Integer size);
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsComposeServiceImpl.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsComposeServiceImpl.java
@@ -171,18 +171,18 @@ public class PostsComposeServiceImpl implements PostsComposeService {
 
 
 
-    @Override
-    public SocialPostListDTO getPostByHashTag(String TagName, Integer page, Integer size) {
-        PageRequest pageRequest = PageRequest.of(page, size);
-
-        Page<Posts> posts = postsQueryService.getPostbyHashTag(TagName, page, size);
-
-        List<PostResponseDTO> postResponseDTOS = posts.getContent().stream().map(this::convertToDTO).collect(Collectors.toList());
-        Page<PostResponseDTO> postResponseDTOPage = new PageImpl<>(postResponseDTOS, pageRequest, posts.getTotalElements());
-        return SocialPostListDTO.builder()
-                .postsList(postResponseDTOPage)
-                .build();
-    }
+//    @Override
+//    public SocialPostListDTO getPostByHashTag(String TagName, Integer page, Integer size) {
+//        PageRequest pageRequest = PageRequest.of(page, size);
+//
+//        Page<Posts> posts = postsQueryService.getPostbyHashTag(TagName, page, size);
+//
+//        List<PostResponseDTO> postResponseDTOS = posts.getContent().stream().map(this::convertToDTO).collect(Collectors.toList());
+//        Page<PostResponseDTO> postResponseDTOPage = new PageImpl<>(postResponseDTOS, pageRequest, posts.getTotalElements());
+//        return SocialPostListDTO.builder()
+//                .postsList(postResponseDTOPage)
+//                .build();
+//    }
 
     private PostResponseDTO convertToDTO(Posts post) {
         return PostResponseDTO.builder()

--- a/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsQueryService.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsQueryService.java
@@ -14,5 +14,5 @@ public interface PostsQueryService {
 
     PostResponse.SocialPostListDTO getPostList(Integer page, Integer size);
 
-    Page<Posts> getPostbyHashTag(String tag, Integer page, Integer size);
+    PostResponse.SocialPostListDTO getPostbyHashTag(String tag, Integer page, Integer size);
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsQueryServiceImpl.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsQueryServiceImpl.java
@@ -34,10 +34,9 @@ public class PostsQueryServiceImpl implements PostsQueryService{
 @Override
 public SocialPostListDTO getPostList(Integer page, Integer size){
         PageRequest pageRequest = PageRequest.of(page, size);
-    Page<Posts> postsPage = postsRepository.findAll(pageRequest);
+    Page<Posts> postsPage = postsRepository.findPosts(PostStatus.POST,pageRequest);
 
     List<PostResponseDTO> postResponseDTOList = postsPage.getContent().stream()
-            .filter(post -> post.getStatus() == PostStatus.POST)
             .map(this::convertToDTO)
             .collect(Collectors.toList());
 
@@ -59,11 +58,27 @@ public SocialPostListDTO getPostList(Integer page, Integer size){
                 .build();
     }
 
-    @Override
-    public Page<Posts> getPostbyHashTag(String tag, Integer page, Integer size){
-        PageRequest pageRequest = PageRequest.of(page, size);
+//    @Override
+//    public Page<Posts> getPostbyHashTag(String tag, Integer page, Integer size){
+//        PageRequest pageRequest = PageRequest.of(page, size);
+//        return postsRepository.findPostsByHashtagName(tag,PostStatus.POST,pageRequest);
+//    }
 
-        return postsRepository.findPostsByHashtagName(tag,pageRequest);
+    @Override
+    public SocialPostListDTO getPostbyHashTag(String tag, Integer page, Integer size){
+        PageRequest pageRequest = PageRequest.of(page, size);
+        Page<Posts> postsPage = postsRepository.findPostsByHashtagName(tag,PostStatus.POST,pageRequest);
+
+        List<PostResponseDTO> postResponseDTOList = postsPage.getContent().stream()
+                .map(this::convertToDTO)
+                .collect(Collectors.toList());
+
+
+        Page<PostResponseDTO> postResponseDTOPage = new PageImpl<>(postResponseDTOList, pageRequest, postsPage.getTotalElements());
+
+        return SocialPostListDTO.builder()
+                .postsList(postResponseDTOPage)
+                .build();
     }
 
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/posts/controller/PostsController.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/posts/controller/PostsController.java
@@ -75,7 +75,7 @@ public class PostsController {
     @Operation(summary = "소셜 피드 해시태그로 조회", description = "소셜 피드 게시글을 해시태그별로 조회합니다")
     @GetMapping("/social/{tag}")
     public ApiResponse<PostResponse.SocialPostListDTO> getPostByTag(@PathVariable String tag, @RequestParam Integer page, @RequestParam Integer size){
-        return ApiResponse.onSuccess(postsComposeService.getPostByHashTag(tag,page,size));
+        return ApiResponse.onSuccess(postsQueryService.getPostbyHashTag(tag,page,size));
     }
 
 

--- a/article-service/src/main/java/com/newcord/articleservice/domain/posts/repository/PostsRepository.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/posts/repository/PostsRepository.java
@@ -1,6 +1,7 @@
 package com.newcord.articleservice.domain.posts.repository;
 
 import com.newcord.articleservice.domain.posts.entity.Posts;
+import com.newcord.articleservice.domain.posts.enums.PostStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,7 +13,10 @@ public interface PostsRepository extends JpaRepository<Posts, Long> {
 //    @Query("SELECT h FROM Posts h WHERE h.hashtags = :tagName")
 //    List<Posts> findAllByHashtags(Long id);
 
-    @Query("SELECT p FROM Posts p JOIN p.hashtags h WHERE h.tagName = :hashtagName")
-    Page<Posts> findPostsByHashtagName(String hashtagName, Pageable pageable);
+    @Query("SELECT p FROM Posts p JOIN p.hashtags h WHERE h.tagName = :hashtagName and p.status =:postStatus")
+    Page<Posts> findPostsByHashtagName(String hashtagName, PostStatus postStatus,Pageable pageable);
+
+    @Query("SELECT p FROM Posts p WHERE p.status =:status")
+    Page<Posts> findPosts(PostStatus status,Pageable pageable);
 }
 


### PR DESCRIPTION
# 요약
- 게시글 상태 post인것만 조회하는 코드 수정했습니다
- 유저 페이지에서 활동탭에 유저가 댓글 남긴 게시글 조회할 수 있도록 추가

# 변경사항
- 기존 게시글 조회 코드는 page로 가져온 후 post인 것만 거름 -> 쿼리로 post인 걸로 조회

# 결과
- 결과를 보여주는 사진이나 로그를 첨부해주세요

# 이슈넘버
- JIRA 이슈 번호를 입력해주세요
