### PR TITLE
Kov 364 [Feat]게시글 제목, 해시태그 웹소켓 전환

### DIFF
--- a/article-service/src/main/java/com/newcord/articleservice/domain/article_version/entity/OperationEntityType.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/article_version/entity/OperationEntityType.java
@@ -1,5 +1,5 @@
 package com.newcord.articleservice.domain.article_version.entity;
 
 public enum OperationEntityType {
-    BLOCK, TEXT, TAG
+    BLOCK, TEXT, TAG, TITLE, HASHTAG
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/article_version/service/ArticleVersionCommandServiceImpl.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/article_version/service/ArticleVersionCommandServiceImpl.java
@@ -1,6 +1,7 @@
 package com.newcord.articleservice.domain.article_version.service;
 
 import com.newcord.articleservice.domain.article_version.entity.ArticleVersion;
+import com.newcord.articleservice.domain.article_version.entity.OperationEntityType;
 import com.newcord.articleservice.domain.article_version.entity.OperationType;
 import com.newcord.articleservice.domain.article_version.entity.Version;
 import com.newcord.articleservice.domain.article_version.entity.VersionOperation;
@@ -46,6 +47,12 @@ public class ArticleVersionCommandServiceImpl implements ArticleVersionCommandSe
                             continue;
                         if(serverOperation.getEntityType() != appliedOperation.getEntityType()) {
                             continue;
+                        }
+                        // 텍스트 수정(블럭 내부)인 경우, 같은 블럭끼리만 OT수행해야함
+                        if(serverOperation.getEntityType().equals(OperationEntityType.TEXT)){
+                            if(!serverOperation.getId().equals(appliedOperation.getId())){
+                                continue;
+                            }
                         }
 
                         if(appliedOperation.getOperationType().equals(OperationType.INSERT)){

--- a/article-service/src/main/java/com/newcord/articleservice/domain/articles/controller/ArticleController.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/articles/controller/ArticleController.java
@@ -1,8 +1,10 @@
 package com.newcord.articleservice.domain.articles.controller;
 
 import com.newcord.articleservice.domain.articles.dto.ArticleRequest.BlockSequenceUpdateRequestDTO;
+import com.newcord.articleservice.domain.articles.dto.ArticleRequest.HashtagUpdateRequestDTO;
 import com.newcord.articleservice.domain.articles.dto.ArticleRequest.TitleUpdateRequestDTO;
 import com.newcord.articleservice.domain.articles.dto.ArticleResponse.BlockSequenceUpdateResponseDTO;
+import com.newcord.articleservice.domain.articles.dto.ArticleResponse.HashtagUpdateResponseDTO;
 import com.newcord.articleservice.domain.articles.dto.ArticleResponse.TitleUpdateResponseDTO;
 import com.newcord.articleservice.domain.articles.service.ArticleComposeService;
 import com.newcord.articleservice.global.common.WSRequest;
@@ -41,5 +43,13 @@ public class ArticleController {
         return response;
     }
     // 해시태그 수정 ws api
+    @MessageMapping("/updateHashtags/{postID}")
+    public WSResponse<HashtagUpdateResponseDTO> updateHashtag(WSRequest<HashtagUpdateRequestDTO> requestDTO, @DestinationVariable Long postID) {
+        HashtagUpdateResponseDTO responseDTO = articleComposeService.updateHashtags(requestDTO.getUserID(), postID, requestDTO.getDto());
+        WSResponse<HashtagUpdateResponseDTO> response = WSResponse.onSuccess("/updateHashtags/"+postID, requestDTO.getUuid(), responseDTO);
+        rabbitMQService.sendMessage(postID.toString(), "", response);
+
+        return response;
+    }
 
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/articles/controller/ArticleController.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/articles/controller/ArticleController.java
@@ -1,7 +1,9 @@
 package com.newcord.articleservice.domain.articles.controller;
 
 import com.newcord.articleservice.domain.articles.dto.ArticleRequest.BlockSequenceUpdateRequestDTO;
+import com.newcord.articleservice.domain.articles.dto.ArticleRequest.TitleUpdateRequestDTO;
 import com.newcord.articleservice.domain.articles.dto.ArticleResponse.BlockSequenceUpdateResponseDTO;
+import com.newcord.articleservice.domain.articles.dto.ArticleResponse.TitleUpdateResponseDTO;
 import com.newcord.articleservice.domain.articles.service.ArticleComposeService;
 import com.newcord.articleservice.global.common.WSRequest;
 import com.newcord.articleservice.global.common.response.WSResponse;
@@ -28,5 +30,16 @@ public class ArticleController {
 
         return response;
     }
+
+    //제목 수정 ws api
+    @MessageMapping("/updateTitle/{postID}")
+    public WSResponse<TitleUpdateResponseDTO> updateTitle(WSRequest<TitleUpdateRequestDTO> requestDTO, @DestinationVariable Long postID) {
+        TitleUpdateResponseDTO responseDTO = articleComposeService.updateTitle(requestDTO.getUserID(), postID, requestDTO.getDto());
+        WSResponse<TitleUpdateResponseDTO> response = WSResponse.onSuccess("/updateTitle/"+postID, requestDTO.getUuid(), responseDTO);
+        rabbitMQService.sendMessage(postID.toString(), "", response);
+
+        return response;
+    }
+    // 해시태그 수정 ws api
 
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/articles/dto/ArticleRequest.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/articles/dto/ArticleRequest.java
@@ -46,4 +46,16 @@ public class ArticleRequest {
         }
     }
 
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class HashtagUpdateRequestDTO {
+        private Long articleID;
+        private String articleVersion;
+        private OperationType operationType;
+        private OperationEntityType entityType;
+        private String tagName;
+        private BlockUpdatedBy updated_by;
+    }
+
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/articles/dto/ArticleRequest.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/articles/dto/ArticleRequest.java
@@ -5,6 +5,7 @@ import com.newcord.articleservice.domain.article_version.entity.OperationType;
 import com.newcord.articleservice.domain.block.entity.Block;
 import com.newcord.articleservice.domain.block.entity.BlockUpdatedBy;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -26,6 +27,23 @@ public class ArticleRequest {
         private OperationType operationType;    // Operation Type (TEXT_INSERT, TEXT_DELETE, TAG)
         private OperationEntityType entityType;  // Operation Entity Type
         private BlockUpdatedBy updated_by;      // 수정자
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class TitleUpdateRequestDTO {
+        private Long articleID;
+        private String articleVersion; // {version index}.{operation index} 형태
+        private OperationType operationType;    // Operation Type (TEXT_INSERT, TEXT_DELETE, TAG, TITLE, HASHTAG)
+        private OperationEntityType entityType;  // Operation Entity Type
+        private Long position;                  // 블럭 내에서 위치
+        private String content;                 // 내용               OperationType이 TEXT_INSERT, TEXT_DELETE인 경우 필수
+        private BlockUpdatedBy updated_by;      // 수정자
+
+        public void setPosition(Long position) {
+            this.position = position;
+        }
     }
 
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/articles/dto/ArticleResponse.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/articles/dto/ArticleResponse.java
@@ -5,6 +5,7 @@ import com.newcord.articleservice.domain.article_version.entity.OperationType;
 import com.newcord.articleservice.domain.block.entity.Block;
 import com.newcord.articleservice.domain.block.entity.BlockUpdatedBy;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -28,6 +29,19 @@ public class ArticleResponse {
         private OperationType operationType;    // Operation Type (TEXT_INSERT, TEXT_DELETE, TAG)
         private OperationEntityType entityType;  // Operation Entity Type
         private List<String> blockList;
+        private BlockUpdatedBy updated_by;      // 수정자
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class TitleUpdateResponseDTO {
+        private Long articleId;
+        private String articleVersion; // {version index}.{operation index} 형태
+        private OperationType operationType;    // Operation Type (TEXT_INSERT, TEXT_DELETE, TAG)
+        private OperationEntityType entityType;  // Operation Entity Type
+        private Long position;                  // 블럭 내에서 위치
+        private String content;                 // 내용               OperationType이 TEXT_INSERT, TEXT_DELETE인 경우 필수
         private BlockUpdatedBy updated_by;      // 수정자
     }
 

--- a/article-service/src/main/java/com/newcord/articleservice/domain/articles/dto/ArticleResponse.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/articles/dto/ArticleResponse.java
@@ -45,4 +45,16 @@ public class ArticleResponse {
         private BlockUpdatedBy updated_by;      // 수정자
     }
 
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class HashtagUpdateResponseDTO {
+        private Long articleID;
+        private String articleVersion;
+        private OperationType operationType;
+        private OperationEntityType entityType;
+        private String tagName;
+        private BlockUpdatedBy updated_by;
+    }
+
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/articles/service/ArticleComposeService.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/articles/service/ArticleComposeService.java
@@ -1,10 +1,12 @@
 package com.newcord.articleservice.domain.articles.service;
 
 import com.newcord.articleservice.domain.articles.dto.ArticleRequest.BlockSequenceUpdateRequestDTO;
+import com.newcord.articleservice.domain.articles.dto.ArticleRequest.HashtagUpdateRequestDTO;
 import com.newcord.articleservice.domain.articles.dto.ArticleRequest.InsertBlockRequestDTO;
 import com.newcord.articleservice.domain.articles.dto.ArticleRequest.TitleUpdateRequestDTO;
 import com.newcord.articleservice.domain.articles.dto.ArticleResponse.ArticleCreateResponseDTO;
 import com.newcord.articleservice.domain.articles.dto.ArticleResponse.BlockSequenceUpdateResponseDTO;
+import com.newcord.articleservice.domain.articles.dto.ArticleResponse.HashtagUpdateResponseDTO;
 import com.newcord.articleservice.domain.articles.dto.ArticleResponse.TitleUpdateResponseDTO;
 import com.newcord.articleservice.domain.block.entity.Block;
 import java.util.List;
@@ -13,5 +15,5 @@ public interface ArticleComposeService {
     BlockSequenceUpdateResponseDTO updateBlockSequence(Long userID, Long articleID,
         BlockSequenceUpdateRequestDTO blockSequenceUpdateRequestDTO);        // 게시글 내 블럭 순서 변경
     TitleUpdateResponseDTO updateTitle(Long userID, Long articleID, TitleUpdateRequestDTO titleUpdateRequestDTO);        // 게시글 제목 변경
-
+    HashtagUpdateResponseDTO updateHashtags(Long userID, Long postID, HashtagUpdateRequestDTO dto);
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/articles/service/ArticleComposeService.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/articles/service/ArticleComposeService.java
@@ -2,13 +2,16 @@ package com.newcord.articleservice.domain.articles.service;
 
 import com.newcord.articleservice.domain.articles.dto.ArticleRequest.BlockSequenceUpdateRequestDTO;
 import com.newcord.articleservice.domain.articles.dto.ArticleRequest.InsertBlockRequestDTO;
+import com.newcord.articleservice.domain.articles.dto.ArticleRequest.TitleUpdateRequestDTO;
 import com.newcord.articleservice.domain.articles.dto.ArticleResponse.ArticleCreateResponseDTO;
 import com.newcord.articleservice.domain.articles.dto.ArticleResponse.BlockSequenceUpdateResponseDTO;
+import com.newcord.articleservice.domain.articles.dto.ArticleResponse.TitleUpdateResponseDTO;
 import com.newcord.articleservice.domain.block.entity.Block;
 import java.util.List;
 
 public interface ArticleComposeService {
     BlockSequenceUpdateResponseDTO updateBlockSequence(Long userID, Long articleID,
         BlockSequenceUpdateRequestDTO blockSequenceUpdateRequestDTO);        // 게시글 내 블럭 순서 변경
+    TitleUpdateResponseDTO updateTitle(Long userID, Long articleID, TitleUpdateRequestDTO titleUpdateRequestDTO);        // 게시글 제목 변경
 
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/hashtags/entity/Hashtags.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/hashtags/entity/Hashtags.java
@@ -27,9 +27,21 @@ public class Hashtags extends BaseJPATimeEntity {
     private Long id;
     private String tagName;
 
-    @ManyToMany(mappedBy = "hashtags")
-    @JsonBackReference
-    @Default
-    private Set<Posts> posts = new HashSet<>();
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        Hashtags hashtags = (Hashtags) obj;
+        return id.equals(hashtags.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
 }
 

--- a/article-service/src/main/java/com/newcord/articleservice/domain/hashtags/service/HashtagsQueryService.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/hashtags/service/HashtagsQueryService.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 
 public interface HashtagsQueryService {
     Hashtags findByID(Long id);
-    Hashtags findByTagName(String tagName);
+    Optional<Hashtags> findByTagName(String tagName);
     Optional<Hashtags> findByTagNameOptional(String tagName);
 
     List<Hashtags> findIdByTagName(String tagName);

--- a/article-service/src/main/java/com/newcord/articleservice/domain/hashtags/service/HashtagsQueryServiceImpl.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/hashtags/service/HashtagsQueryServiceImpl.java
@@ -23,9 +23,8 @@ public class HashtagsQueryServiceImpl implements HashtagsQueryService{
     }
 
     @Override
-    public Hashtags findByTagName(String tagName) {
-        return hashtagsRepository.findByTagName(tagName).orElseThrow(() -> new ApiException(
-            ErrorStatus._HASHTAGS_NOT_FOUND));
+    public Optional<Hashtags> findByTagName(String tagName) {
+        return hashtagsRepository.findByTagName(tagName);
     }
 
     //이거 왜 안됨?

--- a/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsCommandService.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsCommandService.java
@@ -12,5 +12,7 @@ public interface PostsCommandService {
     Posts updatePost(Long userID, PostUpdateRequestDTO postUpdateDTO);        //게시글 수정
     Posts updateTitle(Long userID, Long postId, int position, String contnet);
     Posts updateHashtags(Long postId, List<Hashtags> hashtags);        //해시태그 업데이트 (대체)
+    Posts addHashtags(Long postId, Hashtags hashtag);        //해시태그 추가
+    Posts removeHashtags(Long postId, Hashtags hashtag);        //해시태그 삭제
     void deletePost(Long postId);        //게시글 삭제 (편집자 검증을 거치지 않음)
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsCommandService.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsCommandService.java
@@ -10,6 +10,7 @@ public interface PostsCommandService {
 
     Posts createPost(Long userID, PostCreateRequestDTO postCreateDTO);        //게시글 생성
     Posts updatePost(Long userID, PostUpdateRequestDTO postUpdateDTO);        //게시글 수정
+    Posts updateTitle(Long userID, Long postId, int position, String contnet);
     Posts updateHashtags(Long postId, List<Hashtags> hashtags);        //해시태그 업데이트 (대체)
     void deletePost(Long postId);        //게시글 삭제 (편집자 검증을 거치지 않음)
 }

--- a/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsCommandServiceImpl.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsCommandServiceImpl.java
@@ -40,6 +40,19 @@ public class PostsCommandServiceImpl implements PostsCommandService{
     }
 
     @Override
+    public Posts updateTitle(Long userID, Long postId, int position, String contnet) {
+        Posts post = postsRepository.findById(postId).orElseThrow(() -> new ApiException(
+                ErrorStatus._POSTS_NOT_FOUND));
+
+        String title = post.getTitle();
+        title = title.substring(0, position) + contnet + title.substring(position);
+        post.setTitle(title);
+
+        postsRepository.save(post);
+        return post;
+    }
+
+    @Override
     public Posts updateHashtags(Long postId, List<Hashtags> hashtags) {
         Posts post = postsRepository.findById(postId).orElseThrow(() -> new ApiException(
                 ErrorStatus._POSTS_NOT_FOUND));

--- a/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsCommandServiceImpl.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/posts/Service/PostsCommandServiceImpl.java
@@ -8,6 +8,7 @@ import com.newcord.articleservice.domain.posts.repository.PostsRepository;
 import com.newcord.articleservice.global.common.exception.ApiException;
 import com.newcord.articleservice.global.common.response.code.status.ErrorStatus;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,6 +59,34 @@ public class PostsCommandServiceImpl implements PostsCommandService{
                 ErrorStatus._POSTS_NOT_FOUND));
 
         post.updateHashtagList(hashtags);
+        postsRepository.save(post);
+
+        return post;
+    }
+
+    @Override
+    public Posts addHashtags(Long postId, Hashtags hashtag) {
+        Posts post = postsRepository.findById(postId).orElseThrow(() -> new ApiException(
+                ErrorStatus._POSTS_NOT_FOUND));
+
+        Set<Hashtags> hashtags = post.getHashtags();
+        hashtags.add(hashtag);
+        post.updateHashtagList(hashtags);
+
+        postsRepository.save(post);
+
+        return post;
+    }
+
+    @Override
+    public Posts removeHashtags(Long postId, Hashtags hashtag) {
+        Posts post = postsRepository.findById(postId).orElseThrow(() -> new ApiException(
+            ErrorStatus._POSTS_NOT_FOUND));
+
+        Set<Hashtags> hashtags = post.getHashtags();
+        hashtags.remove(hashtag);
+        post.updateHashtagList(hashtags);
+
         postsRepository.save(post);
 
         return post;

--- a/article-service/src/main/java/com/newcord/articleservice/domain/posts/entity/Posts.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/posts/entity/Posts.java
@@ -47,6 +47,10 @@ public class Posts extends BaseJPATimeEntity {
         this.hashtags = new HashSet<>(hashtag);
     }
 
+    public void setTitle(String title){
+        this.title = title;
+    }
+
     public void updateByDTO(PostUpdateRequestDTO updateRequestDTO){
         if (updateRequestDTO.getThumbnail() != null) this.thumbnail = updateRequestDTO.getThumbnail();
         if (updateRequestDTO.getTitle() != null) this.title = updateRequestDTO.getTitle();

--- a/article-service/src/main/java/com/newcord/articleservice/domain/posts/entity/Posts.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/posts/entity/Posts.java
@@ -43,8 +43,11 @@ public class Posts extends BaseJPATimeEntity {
     @Default
     private Set<Hashtags> hashtags = new HashSet<>();
 
-    public void updateHashtagList(List<Hashtags> hashtag){
-        this.hashtags = new HashSet<>(hashtag);
+    public void updateHashtagList(List<Hashtags> hashtags){
+        this.hashtags = new HashSet<>(hashtags);
+    }
+    public void updateHashtagList(Set<Hashtags> hashtags){
+        this.hashtags = hashtags;
     }
 
     public void setTitle(String title){


### PR DESCRIPTION
# 요약
- 제목과 해시태그 수정을 웹소켓을 통해 실시간 협업으로 가능하게 하였습니다.

# 변경사항
- 웹소켓 기능 구현

# 결과
- 제목 수정 화면. (로그 확인)
<img width="760" alt="image" src="https://github.com/KEA-Kovengers/Backend/assets/32007781/d7a405fd-bd99-4c13-86f6-6ffcdb49fc14">


# 이슈넘버
- JIRA 이슈 번호를 입력해주세요
