### PR TITLE
[FEAT] 게시글 서비스 jwt 인증 요청 구현

### DIFF
--- a/article-service/src/main/java/com/newcord/articleservice/domain/comments/controller/CommentsController.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/comments/controller/CommentsController.java
@@ -21,7 +21,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 @Tag(name = "Comment", description = "댓글 API")
-@RequestMapping("/articles/comment")
+@RequestMapping("/comment")
 public class CommentsController {
 
     private final CommentsComposeService commentsComposeService;

--- a/article-service/src/main/java/com/newcord/articleservice/domain/report/controller/ReportController.java
+++ b/article-service/src/main/java/com/newcord/articleservice/domain/report/controller/ReportController.java
@@ -20,7 +20,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 @Tag(name = "Report", description = "신고 API")
-@RequestMapping("/articles/report")
+@RequestMapping("/report")
 public class ReportController {
     private final ReportCommandService reportCommandService;
     private final ReportQueryService reportQueryService;

--- a/article-service/src/main/java/com/newcord/articleservice/global/common/response/code/status/ErrorStatus.java
+++ b/article-service/src/main/java/com/newcord/articleservice/global/common/response/code/status/ErrorStatus.java
@@ -2,6 +2,8 @@ package com.newcord.articleservice.global.common.response.code.status;
 
 import com.newcord.articleservice.global.common.response.code.BaseErrorCode;
 import com.newcord.articleservice.global.common.response.code.ErrorReasonDTO;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;

--- a/article-service/src/main/java/com/newcord/articleservice/global/jwt/JwtFilter.java
+++ b/article-service/src/main/java/com/newcord/articleservice/global/jwt/JwtFilter.java
@@ -1,0 +1,99 @@
+package com.newcord.articleservice.global.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.newcord.articleservice.global.common.exception.ApiException;
+import com.newcord.articleservice.global.common.response.ApiResponse;
+import com.newcord.articleservice.global.common.response.code.status.ErrorStatus;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import java.util.Enumeration;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.filter.GenericFilterBean;
+
+@RequiredArgsConstructor
+public class JwtFilter extends GenericFilterBean {
+    private final JwtTokenProvider jwtTokenProvider;
+    @Autowired
+    private final RestTemplate restTemplate;
+    private String[] balckListArray = {
+        "/report/**",
+        "/posts/createPost", "/posts/editPost", "/posts/updateHashtags", "/posts/deleteEditSession", "/posts/createEditSession"
+        ,"/comment/delete", "/articles/comment/create"};
+    private List<String> blackList = Arrays.asList(balckListArray);
+
+
+    @Override
+    public void doFilter(
+        ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException, ApiException {
+
+        String rUrl = ((HttpServletRequest) request).getRequestURI();
+        if(!blackList.contains(rUrl)){
+            chain.doFilter(request, response);
+            return;
+        }
+        String token = ((HttpServletRequest) request).getHeader("Authorization");
+
+        if(token == null || !token.startsWith("Bearer ")){
+            response.setContentType("application/json");
+            ((HttpServletResponse) response).setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+            ObjectMapper objectMapper = new ObjectMapper();
+            String json = objectMapper.writeValueAsString(ErrorStatus._UNAUTHORIZED.getReasonHttpStatus());
+            response.getWriter().write(json);
+            return;
+        }
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", token);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        try{
+            ResponseEntity<Map> authResponse = restTemplate.exchange("http://newcord.kro.kr/users/auth/validate", HttpMethod.GET,
+                entity, Map.class);
+
+            if(Boolean.FALSE.equals(authResponse.getBody().get("result"))){
+                response.setContentType("application/json");
+                ((HttpServletResponse) response).setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+                ObjectMapper objectMapper = new ObjectMapper();
+                String json = objectMapper.writeValueAsString(ErrorStatus._UNAUTHORIZED.getReasonHttpStatus());
+                response.getWriter().write(json);
+                return;
+            }
+        } catch (Exception e){
+            response.setContentType("application/json");
+            ((HttpServletResponse) response).setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+            ObjectMapper objectMapper = new ObjectMapper();
+            String json = objectMapper.writeValueAsString(ErrorStatus._UNAUTHORIZED.getReasonHttpStatus());
+            response.getWriter().write(json);
+            return;
+        }
+
+        // 다음 필터링
+        chain.doFilter(request, response);
+    }
+
+    private void handleException(HttpServletResponse response, ApiException ex) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+    }
+
+}


### PR DESCRIPTION
# 요약
- 게시글 서비스의 JWT인증 로직 구현했습니다.

# 변경사항
- 유저 서비스의 validate api를 통해 filter로 JWT검증 로직을 추가했습니다.
- 인증이 필요한 API경로만 blacklist에 추가하여 검증하도록 하였습니다.
- 한글이 깨지는건 response가 유니코드를 지원하지 않는것으로 생각되는데 급한일은 아니라서 해결하지 않았습니다.

# 결과
- 성공
<img width="1624" alt="image" src="https://github.com/KEA-Kovengers/Backend/assets/32007781/d87f0230-89ad-4766-a66b-d42ff49b7167">

- 토큰이 없는 경우
<img width="1624" alt="image" src="https://github.com/KEA-Kovengers/Backend/assets/32007781/14a1eb32-e0dd-42a7-ac37-e1cce8e02c9f">
- 토큰이 올바르지 않은 경우

<img width="1624" alt="image" src="https://github.com/KEA-Kovengers/Backend/assets/32007781/fddebe69-776a-4982-be28-91e27fc32d1b">


# 이슈넘버
- JIRA 이슈 번호를 입력해주세요
